### PR TITLE
Use Github token to resolve npm token

### DIFF
--- a/.github/workflows/feature-branches.yml
+++ b/.github/workflows/feature-branches.yml
@@ -18,9 +18,7 @@ jobs:
     # do not run when if it is a manual trigger on the main branch as we have other CI for this. This one is only for feature branches
     if: (github.event_name != 'workflow_dispatch' || github.ref != 'refs/heads/main') && !github.event.pull_request.draft
     env:
-      NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
       NPM_CONFIG_@coremedia:registry: 'https://npm.coremedia.io'
-      NPM_CONFIG_//npm.coremedia.io/:_authToken: ${NPM_AUTH_TOKEN}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -37,6 +35,11 @@ jobs:
           node-version: 14.x
       - name: Configure NPM
         run: |
+          NPM_AUTH_TOKEN=$(curl -s -H "Accept: application/json" -H "Content-Type:application/json" -X PUT --data '{"name": "${{ secrets.USER_COREMEDIA_NPM_REGISTRY }}", "password": "${{ secrets.TOKEN_COREMEDIA_NPM_REGISTRY }}"}' https://npm.coremedia.io/-/user/org.couchdb.user:${{ secrets.USER_COREMEDIA_NPM_REGISTRY }} | jq -r .token)
+          echo "::add-mask::$NPM_AUTH_TOKEN"
+          echo "NPM_AUTH_TOKEN=$NPM_AUTH_TOKEN" >> $GITHUB_ENV
+          echo "NPM_CONFIG_//npm.coremedia.io/:_authToken=$NPM_AUTH_TOKEN" >> $GITHUB_ENV
+
           npm install -g npm@latest
           npm install -g pnpm@6.15.1
           npm install -g semver

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,9 +17,7 @@ jobs:
   build:
     name: Build
     env:
-      NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
       NPM_CONFIG_@coremedia:registry: 'https://npm.coremedia.io'
-      NPM_CONFIG_//npm.coremedia.io/:_authToken: ${NPM_AUTH_TOKEN}
     runs-on: ubuntu-latest
     if: github.actor != 'coremedia-ci' && github.actor != 'github-action[bot]'
     steps:
@@ -48,6 +46,11 @@ jobs:
           node-version: 14.x
       - name: Configure NPM
         run: |
+          NPM_AUTH_TOKEN=$(curl -s -H "Accept: application/json" -H "Content-Type:application/json" -X PUT --data '{"name": "${{ secrets.USER_COREMEDIA_NPM_REGISTRY }}", "password": "${{ secrets.TOKEN_COREMEDIA_NPM_REGISTRY }}"}' https://npm.coremedia.io/-/user/org.couchdb.user:${{ secrets.USER_COREMEDIA_NPM_REGISTRY }} | jq -r .token)
+          echo "::add-mask::$NPM_AUTH_TOKEN"
+          echo "NPM_AUTH_TOKEN=$NPM_AUTH_TOKEN" >> $GITHUB_ENV
+          echo "NPM_CONFIG_//npm.coremedia.io/:_authToken=$NPM_AUTH_TOKEN" >> $GITHUB_ENV
+
           npm install -g npm@latest
           npm install -g pnpm@6.15.1
           npm install -g semver

--- a/.github/workflows/unpublish.yml
+++ b/.github/workflows/unpublish.yml
@@ -9,15 +9,15 @@ jobs:
   build:
     name: Unpublish Version
     env:
-      NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
       NPM_CONFIG_@coremedia:registry: 'https://npm.coremedia.io'
-      NPM_CONFIG_//npm.coremedia.io/:_authToken: ${NPM_AUTH_TOKEN}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Unpublish release
         run: |
+          NPM_AUTH_TOKEN=$(curl -s -H "Accept: application/json" -H "Content-Type:application/json" -X PUT --data '{"name": "${{ secrets.USER_COREMEDIA_NPM_REGISTRY }}", "password": "${{ secrets.TOKEN_COREMEDIA_NPM_REGISTRY }}"}' https://npm.coremedia.io/-/user/org.couchdb.user:${{ secrets.USER_COREMEDIA_NPM_REGISTRY }} | jq -r .token)
+          echo "::add-mask::$NPM_AUTH_TOKEN"
           echo '//npm.coremedia.io/:_authToken=${NPM_AUTH_TOKEN}' > .npmrc
 
           version=${{ github.event.inputs.version }}


### PR DESCRIPTION
The npm token is a session token which gets invalidated after some time and we would have to update the token frequently.
Better is to use a controlled Github token to resolve the NPM Token for.
We must never output the session token.