### PR TITLE
fix(#39): Fixes Corrupted XML Entities in CoreMedia RichText Data

### DIFF
--- a/app/src/example-data.js
+++ b/app/src/example-data.js
@@ -17,6 +17,20 @@ const UNSET = "—";
 const parser = new DOMParser();
 const serializer = new XMLSerializer();
 const xmlDocument = parser.parseFromString(`<div xmlns="${CM_RICHTEXT}" xmlns:xlink="${XLINK}"></div>`, "text/xml");
+const tableHeader = (...headers) => `<tr class="tr--header">${headers.map((h) => `<td class="td--header">${h}</td>`).join("")}</tr>`;
+const htmlCode = (code) => `<pre><span class="language-html code">${code}</span></pre>`;
+const richText = (plain) => {
+  if (!plain) {
+    return `<div xmlns="${CM_RICHTEXT}"/>`
+  }
+  const hasXLink = plain.indexOf("xlink:") >= 0;
+  return `<div xmlns="${CM_RICHTEXT}"${hasXLink ? ` xmlns:xlink="${XLINK}"`: ""}>${plain}</div>`
+};
+const h = (level, text) => `<p class="p--heading-${level}">${text}</p>`;
+const h1 = (text) => h(1, text);
+const h2 = (text) => h(2, text);
+const em = (str) => `<em>${str}</em>`;
+
 
 function createLink(show, role, href = EXAMPLE_URL) {
   const a = xmlDocument.createElement("a");
@@ -69,12 +83,8 @@ function renderUiEditorValue(uiEditorValue) {
   return uiEditorValue || UNSET;
 }
 
-function em(str) {
-  return `<em>${str}</em>`;
-}
-
 function createLinkTableHeading() {
-  return `<tr class="tr--header"><td class="td--header">xlink:show</td><td class="td--header">xlink:role</td><td class="td--header">target</td><td class="td--header">Active Button</td><td class="td--header">Editor Value</td><td class="td--header">Link</td><td class="td--header">Comment</td></tr>`;
+  return tableHeader("xlink:show", "xlink:role", "target", "Active Button", "Editor Value", "Link", "Comment");
 }
 
 function createLinkTableRow({comment, show, role, target, uiActiveButton, uiEditorValue}) {
@@ -91,14 +101,14 @@ function createLinkTableRow({comment, show, role, target, uiActiveButton, uiEdit
 }
 
 function createLinkScenario(title, scenarios) {
-  const scenarioTitle = `<h1>${title}</h1>`;
+  const scenarioTitle = h1(title);
   const scenarioHeader = createLinkTableHeading();
   const scenarioRows = scenarios.map(createLinkTableRow).join("");
   return `${scenarioTitle}<table>${scenarioHeader}${scenarioRows}</table>`;
 }
 
 function createContentLinkTableHeading() {
-  return `<tr class="tr--header"><td class="td--header">Link</td><td class="td--header">Comment</td></tr>`;
+  return tableHeader("Link", "Comment");
 }
 
 function createContentLinkTableRow({comment, id}) {
@@ -106,7 +116,7 @@ function createContentLinkTableRow({comment, id}) {
 }
 
 function createContentLinkScenario(title, scenarios) {
-  const scenarioTitle = `<h1>${title}</h1>`;
+  const scenarioTitle = h1(title);
   const scenarioHeader = createContentLinkTableHeading();
   const scenarioRows = scenarios.map(createContentLinkTableRow).join("");
   return `${scenarioTitle}<table>${scenarioHeader}${scenarioRows}</table>`;
@@ -526,7 +536,7 @@ const lorem = (words, paragraphs) => {
     return `<p>${paragraphText}</p>`;
   };
   const htmlParagraphs = `${asParagraphs.map((w) => paragraph(w)).join("")}`;
-  return `<div xmlns="${CM_RICHTEXT}">${htmlParagraphs}</div>`;
+  return richText(htmlParagraphs);
 };
 
 /**
@@ -546,7 +556,7 @@ const coreMediaRichTextPoC = () => {
   const someLanguage = "en-US";
   const someUrl = EXAMPLE_URL;
   const introduction = () => `
-    <p class="${titleHeading}">CoreMedia RichText 1.0 Examples</p>
+    ${h1("CoreMedia RichText 1.0 Examples")}
     <p>
       CKEditor 5 must provide support for all valid elements, attributes and nested structures,
       which represent valid CoreMedia RichText 1.0.
@@ -728,8 +738,8 @@ const grsExampleData = () => {
   const allAttributesText = "All Attributes";
   const langText = "Lang Precedence";
   const alignedText = "Aligned";
-  const grsHeading = (title) => `<p class="p--heading-1">${grsName}: ${title}</p>`;
-  const examplesHeading = `<p class="p--heading-2">Examples</p>`;
+  const grsHeading = (title) => h1(`${grsName}: ${title}`);
+  const examplesHeading = h2("Examples");
   const listSeparator = `<p>Separator: CKEditor merges lists directly following each other. Thus, separate.</p>`;
 
   /**
@@ -1007,26 +1017,307 @@ const grsExampleData = () => {
   };
 };
 
+/**
+ * These are all CoreMedia RichText Entities known to CoreMedia RichText 1.0
+ * DTD.
+ * @type {string[]}
+ */
+const coreMediaRichTextEntities = [
+  "&AElig;",
+  "&Aacute;",
+  "&Acirc;",
+  "&Agrave;",
+  "&Alpha;",
+  "&Aring;",
+  "&Atilde;",
+  "&Auml;",
+  "&Beta;",
+  "&Ccedil;",
+  "&Chi;",
+  "&Dagger;",
+  "&Delta;",
+  "&ETH;",
+  "&Eacute;",
+  "&Ecirc;",
+  "&Egrave;",
+  "&Epsilon;",
+  "&Eta;",
+  "&Euml;",
+  "&Gamma;",
+  "&Iacute;",
+  "&Icirc;",
+  "&Igrave;",
+  "&Iota;",
+  "&Iuml;",
+  "&Kappa;",
+  "&Lambda;",
+  "&Mu;",
+  "&Ntilde;",
+  "&Nu;",
+  "&OElig;",
+  "&Oacute;",
+  "&Ocirc;",
+  "&Ograve;",
+  "&Omega;",
+  "&Omicron;",
+  "&Oslash;",
+  "&Otilde;",
+  "&Ouml;",
+  "&Phi;",
+  "&Pi;",
+  "&Prime;",
+  "&Psi;",
+  "&Rho;",
+  "&Scaron;",
+  "&Sigma;",
+  "&THORN;",
+  "&Tau;",
+  "&Theta;",
+  "&Uacute;",
+  "&Ucirc;",
+  "&Ugrave;",
+  "&Upsilon;",
+  "&Uuml;",
+  "&Xi;",
+  "&Yacute;",
+  "&Yuml;",
+  "&Zeta;",
+  "&aacute;",
+  "&acirc;",
+  "&acute;",
+  "&aelig;",
+  "&agrave;",
+  "&alefsym;",
+  "&alpha;",
+  "&amp;",
+  "&and;",
+  "&ang;",
+  "&apos;",
+  "&aring;",
+  "&asymp;",
+  "&atilde;",
+  "&auml;",
+  "&bdquo;",
+  "&beta;",
+  "&brvbar;",
+  "&bull;",
+  "&cap;",
+  "&ccedil;",
+  "&cedil;",
+  "&cent;",
+  "&chi;",
+  "&circ;",
+  "&clubs;",
+  "&cong;",
+  "&copy;",
+  "&crarr;",
+  "&cup;",
+  "&curren;",
+  "&dArr;",
+  "&dagger;",
+  "&darr;",
+  "&deg;",
+  "&delta;",
+  "&diams;",
+  "&divide;",
+  "&eacute;",
+  "&ecirc;",
+  "&egrave;",
+  "&empty;",
+  "&emsp;",
+  "&ensp;",
+  "&epsilon;",
+  "&equiv;",
+  "&eta;",
+  "&eth;",
+  "&euml;",
+  "&euro;",
+  "&exist;",
+  "&fnof;",
+  "&forall;",
+  "&frac12;",
+  "&frac14;",
+  "&frac34;",
+  "&frasl;",
+  "&gamma;",
+  "&ge;",
+  "&gt;",
+  "&hArr;",
+  "&harr;",
+  "&hearts;",
+  "&hellip;",
+  "&iacute;",
+  "&icirc;",
+  "&iexcl;",
+  "&igrave;",
+  "&image;",
+  "&infin;",
+  "&int;",
+  "&iota;",
+  "&iquest;",
+  "&isin;",
+  "&iuml;",
+  "&kappa;",
+  "&lArr;",
+  "&lambda;",
+  "&lang;",
+  "&laquo;",
+  "&larr;",
+  "&lceil;",
+  "&ldquo;",
+  "&le;",
+  "&lfloor;",
+  "&lowast;",
+  "&loz;",
+  "&lrm;",
+  "&lsaquo;",
+  "&lsquo;",
+  "&lt;",
+  "&macr;",
+  "&mdash;",
+  "&micro;",
+  "&middot;",
+  "&minus;",
+  "&mu;",
+  "&nabla;",
+  "&nbsp;",
+  "&ndash;",
+  "&ne;",
+  "&ni;",
+  "&not;",
+  "&notin;",
+  "&nsub;",
+  "&ntilde;",
+  "&nu;",
+  "&oacute;",
+  "&ocirc;",
+  "&oelig;",
+  "&ograve;",
+  "&oline;",
+  "&omega;",
+  "&omicron;",
+  "&oplus;",
+  "&or;",
+  "&ordf;",
+  "&ordm;",
+  "&oslash;",
+  "&otilde;",
+  "&otimes;",
+  "&ouml;",
+  "&para;",
+  "&part;",
+  "&permil;",
+  "&perp;",
+  "&phi;",
+  "&pi;",
+  "&piv;",
+  "&plusmn;",
+  "&pound;",
+  "&prime;",
+  "&prod;",
+  "&prop;",
+  "&psi;",
+  "&quot;",
+  "&rArr;",
+  "&radic;",
+  "&rang;",
+  "&raquo;",
+  "&rarr;",
+  "&rceil;",
+  "&rdquo;",
+  "&real;",
+  "&reg;",
+  "&rfloor;",
+  "&rho;",
+  "&rlm;",
+  "&rsaquo;",
+  "&rsquo;",
+  "&sbquo;",
+  "&scaron;",
+  "&sdot;",
+  "&sect;",
+  "&shy;",
+  "&sigma;",
+  "&sigmaf;",
+  "&sim;",
+  "&spades;",
+  "&sub;",
+  "&sube;",
+  "&sum;",
+  "&sup1;",
+  "&sup2;",
+  "&sup3;",
+  "&sup;",
+  "&supe;",
+  "&szlig;",
+  "&tau;",
+  "&there4;",
+  "&theta;",
+  "&thetasym;",
+  "&thinsp;",
+  "&thorn;",
+  "&tilde;",
+  "&times;",
+  "&trade;",
+  "&uArr;",
+  "&uacute;",
+  "&uarr;",
+  "&ucirc;",
+  "&ugrave;",
+  "&uml;",
+  "&upsih;",
+  "&upsilon;",
+  "&uuml;",
+  "&weierp;",
+  "&xi;",
+  "&yacute;",
+  "&yen;",
+  "&yuml;",
+  "&zeta;",
+  "&zwj;",
+  "&zwnj;",
+];
+const entitiesTableRow = (entity) => `<tr><td>${htmlCode(entity.replace("&", "&amp;"))}</td><td>${entity}</td></tr>`;
+/**
+ * These are the default entities, allowed or required in XML.
+ * These entities were affected by CoreMedia/ckeditor-plugins#39.
+ * @type {string[]}
+ */
+const xmlEntities = ["&amp;", "&lt;", "&gt;", "&quot;", "&apos;"].sort();
+const xmlEntityRows = xmlEntities.map(entitiesTableRow).join("");
+const richTextEntityRows = coreMediaRichTextEntities.map(entitiesTableRow).join("");
+const entitiesDescription = `<p>
+  The following entities must be supported when they are part of a
+  CoreMedia RichText&nbsp;1.0 document. While <em>XML Entities</em> lists
+  the default entities, which come with XML (and where not all of them must be
+  resolved to their characters in processing), <em>CoreMedia RichText&nbsp;1.0 Entities</em>
+  are those, which are declared by CoreMedia RichText&nbsp;1.0 DTD.
+</p><p>
+  The behavior for all entities, despite some XML entities like
+  <span class="code">&amp;lt;</span>, is, that when written back to server, these
+  entities are resolved to their corresponding UTF-8 characters.
+</p>`;
+const entitiesExample = richText(`${h1("Entities")}${entitiesDescription}${h2("XML Entities")}<table>${tableHeader("Entity", "Character")}${xmlEntityRows}</table>${h2("CoreMedia RichText&nbsp;1.0 Entities")}<table>${tableHeader("Entity", "Character")}${richTextEntityRows}</table>`);
+
 const exampleData = {
   "Content Links": contentLinkExamples(),
   "CoreMedia RichText": coreMediaRichTextPoC(),
-  "Empty": `<div xmlns="${CM_RICHTEXT}"/>`,
+  "Empty": richText(),
+  "Entities": entitiesExample,
   ...grsExampleData(),
-  "Hello": `<div xmlns="${CM_RICHTEXT}"><p>Hello World!</p></div>`,
+  "Hello": richText(`<p>Hello World!</p>`),
   "Links (Targets)": externalLinkTargetExamples(),
   "Lorem": lorem(LOREM_IPSUM_WORDS.length, 10),
   "Lorem (Huge)": lorem(LOREM_IPSUM_WORDS.length * 10, 80),
   // TODO[cke] The following must be addressed prior to reaching MVP for CKEditor 5 Plugins for CoreMedia CMS
-  "Lists Bug": `<div xmlns="${CM_RICHTEXT}" xmlns:xlink="${XLINK}">
-  <p>
+  "Lists Bug": richText(`<p>
   The following example shows a symptom of
   <a xlink:href="https://github.com/ckeditor/ckeditor5/issues/2973">ckeditor/ckeditor5#2973</a>,
   which is, that more complex lists are not supported yet — a known issue since
   2017. If we cannot find a workaround, we will not be able editing valid
   CoreMedia RichText 1.0 (and HTML) lists within CKEditor 5.
   </p>
-  <ul><li>Lorem</li><li><p>Ipsum</p></li><li>Dolor</li></ul>
-  </div>`,
+  <ul><li>Lorem</li><li><p>Ipsum</p></li><li>Dolor</li></ul>`),
 };
 
 const setExampleData = (editor, exampleKey) => {

--- a/app/src/example-data.js
+++ b/app/src/example-data.js
@@ -1306,6 +1306,8 @@ const exampleData = {
   "Entities": entitiesExample,
   ...grsExampleData(),
   "Hello": richText(`<p>Hello World!</p>`),
+  "Invalid RichText": richText(`${h1("Invalid RichText")}<p>Parsing cannot succeed below, because xlink-namespace declaration is missing.</p><p>LINK</p>`)
+          .replace("LINK", `<a xlink:href="https://example.org/">Link</a>`),
   "Links (Targets)": externalLinkTargetExamples(),
   "Lorem": lorem(LOREM_IPSUM_WORDS.length, 10),
   "Lorem (Huge)": lorem(LOREM_IPSUM_WORDS.length * 10, 80),

--- a/packages/ckeditor5-coremedia-richtext/src/CoreMediaRichTextConfig.ts
+++ b/packages/ckeditor5-coremedia-richtext/src/CoreMediaRichTextConfig.ts
@@ -65,8 +65,8 @@ const strike: ToDataAndViewElementConfiguration = {
  * <li>If false is returned, the element and all its children will be removed.</li>
  * <li>If element name changes to empty, only the element itself will be removed and the children appended to the parent</li>
  * <li>An element is processed first, then its attributes and afterwards its children (if any)</li>
- * <li>Text nodes only support to be changed or removed... but not to be wrapped into some other params.el.</li>
- * <li><code>$</code> and <code>$$</code> are so called generic element rules which are applied after element
+ * <li>Text nodes only support to be changed or removed… but not to be wrapped into some other params.el.</li>
+ * <li><code>$</code> and <code>$$</code> are so-called generic element rules, which are applied after element
  * processing. <code>$</code> is applied prior to filtering the children, while <code>$$</code> is applied
  * after the element and all its children have been processed.
  * The opposite handler is <code>'^'</code> which would be applied before all other element handlers.</li>
@@ -76,9 +76,11 @@ const defaultRules: FilterRuleSetConfiguration = {
   text: (params) => {
     if (!getSchema(params).isTextAllowedAtParent(params.node)) {
       params.node.remove = true;
-    } else {
-      params.node.decodeHtmlEntities();
     }
+    // In CKEditor 4 we were used resolving entities here to their
+    // UTF-8 characters. With CKEditor 5 this is unnecessary, as it
+    // is the default behavior when it comes to storing data.
+    // Not doing so here, fixes #39.
   },
   elements: {
     ...schemaRules,

--- a/packages/ckeditor5-dataprocessor-support/__tests__/TextProxy.test.ts
+++ b/packages/ckeditor5-dataprocessor-support/__tests__/TextProxy.test.ts
@@ -66,7 +66,7 @@ interface TextFilterTestData extends CommentableTestData, DisablableTestData {
    */
   nodePath: string;
   /**
-   * XPath for a node in `to` result which should have been returned as
+   * XPath for a node in `to` result, which should have been returned as
    * `restartFrom`. Will not be checked, if unset.
    */
   restartPath?: string;
@@ -139,34 +139,6 @@ describe("TextProxy.applyRules()", () => {
         ],
         from: `<parent><el>${asciiText}</el></parent>`,
         to: `<parent><el>${otherAsciiText}</el></parent>`,
-        nodePath: "//el/text()[1]",
-      },
-    ],
-    [
-      "ENTITY#01: Should replace numeric entity by UTF-8 characters.",
-      {
-        rules: [
-          (p) => {
-            p.node.textContent = "Lorem&#xa0;Ipsum";
-            p.node.decodeHtmlEntities();
-          },
-        ],
-        from: `<parent><el>Replace Me</el></parent>`,
-        to: `<parent><el>Lorem\xa0Ipsum</el></parent>`,
-        nodePath: "//el/text()[1]",
-      },
-    ],
-    [
-      "ENTITY#02: Should replace named entity by UTF-8 characters.",
-      {
-        rules: [
-          (p) => {
-            p.node.textContent = "Lorem&nbsp;Ipsum";
-            p.node.decodeHtmlEntities();
-          },
-        ],
-        from: `<parent><el>Replace Me</el></parent>`,
-        to: `<parent><el>Lorem\xa0Ipsum</el></parent>`,
         nodePath: "//el/text()[1]",
       },
     ],

--- a/packages/ckeditor5-dataprocessor-support/src/TextProxy.ts
+++ b/packages/ckeditor5-dataprocessor-support/src/TextProxy.ts
@@ -9,11 +9,6 @@ import Editor from "@ckeditor/ckeditor5-core/src/editor/editor";
  */
 export default class TextProxy extends NodeProxy<Text> implements TextFilterParams {
   /**
-   * Helper element for decoding entities.
-   * @private
-   */
-  private readonly decodeElement = document.createElement("div");
-  /**
    * Possibly overridden text.
    * @private
    */
@@ -25,7 +20,7 @@ export default class TextProxy extends NodeProxy<Text> implements TextFilterPara
    * for example.
    * </p>
    * <p>
-   * Mimics `TextFilterParams`, which helps dealing with rule processing.
+   * Mimics `TextFilterParams`, which helps to deal with rule processing.
    * </p>
    */
   public readonly editor: Editor;
@@ -35,7 +30,7 @@ export default class TextProxy extends NodeProxy<Text> implements TextFilterPara
    * proxy class itself.
    * </p>
    * <p>
-   * Mimics `TextFilterParams`, which helps dealing with rule processing.
+   * Mimics `TextFilterParams`, which helps to deal with rule processing.
    * </p>
    */
   public readonly node: TextProxy = this;
@@ -115,26 +110,6 @@ export default class TextProxy extends NodeProxy<Text> implements TextFilterPara
   }
 
   /**
-   * Decodes all HTML entities within this text node. This helps to ensure, that
-   * we don't store entities unsupported by the current grammar.
-   *
-   * @see <a href="https://stackoverflow.com/questions/5796718/html-entity-decode">javascript - HTML Entity Decode - Stack Overflow</a>
-   */
-  public decodeHtmlEntities(): void {
-    // noinspection InnerHTMLJS
-    this.decodeElement.innerHTML = this.textContent;
-    const newText = this.decodeElement.textContent;
-    // noinspection InnerHTMLJS
-    this.decodeElement.innerHTML = "";
-
-    // Prevent possible cycles, if re-applying rules because of a recreated
-    // text node.
-    if (newText !== this.textContent) {
-      this._text = newText || "";
-    }
-  }
-
-  /**
    * For kept text-nodes it possibly sets changed text.
    * @protected
    */
@@ -151,9 +126,9 @@ export default class TextProxy extends NodeProxy<Text> implements TextFilterPara
  * Named parameters to be passed to element filters. For overriding filter rules
  * a typical pattern to start with is:
  *
- * <pre>
+ * ```
  * params.parent && params.parent(args);
- * </pre>
+ * ```
  */
 export interface TextFilterParams {
   /**


### PR DESCRIPTION
As described in #39, the previous implementation caused `&lt;` and `&gt;` to be processed to `<` and `>` directly before writing CoreMedia RichText 1.0 Data back to the server. This, for example, caused `Lorem&lt;elem&gt;Ipsum` to be stored as `LoremIpsum`.

The fix is, to remove trying to decode entities in `toData` processing. Once required in CKEditor 4 integration for CoreMedia CMS, it does not match CKEditor 5 behavior nowadays, which is, that entities are always handed over to `toData` processing as resolved UTF-8 characters, rather than raw entities.

### 🚧 Blocked

* #35 needs to be merged prior to this, as the changes base on the changes made on that branch