### PR TITLE
fix(data-processor): Should accept `setData("")`

### DIFF
--- a/app/src/example-data.js
+++ b/app/src/example-data.js
@@ -1302,7 +1302,7 @@ const entitiesExample = richText(`${h1("Entities")}${entitiesDescription}${h2("X
 const exampleData = {
   "Content Links": contentLinkExamples(),
   "CoreMedia RichText": coreMediaRichTextPoC(),
-  "Empty": richText(),
+  "Empty": "",
   "Entities": entitiesExample,
   ...grsExampleData(),
   "Hello": richText(`<p>Hello World!</p>`),


### PR DESCRIPTION
Just as an empty text in data view is transformed to an empty string, we should accept the same string as input to `toView`. Before that, it was required to always pass a valid RichText document (here: representing an empty state).

Now, we skip XML parsing and directly set the empty data. This much more matches the general approach of clearing an editor by setting its data to an empty string.