### PR TITLE
Prevent usage of release version tag "latest" for prerelease builds

### DIFF
--- a/.github/workflows/feature-branches.yml
+++ b/.github/workflows/feature-branches.yml
@@ -74,5 +74,5 @@ jobs:
         run: |
           pnpm install --production
           echo '//npm.coremedia.io/:_authToken=${NPM_AUTH_TOKEN}' > .npmrc
-          pnpm publishall -- --registry=https://npm.coremedia.io --no-git-checks
+          pnpm publishall -- --registry=https://npm.coremedia.io --no-git-checks --tag pullrequest
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,7 +110,16 @@ jobs:
         run: pnpm jest
       - name: Install for Production
         run: pnpm install --production
-      - name: Publish
+      # Publishes a release candidate with tag "next".
+      - name: Publish RC
+        if: github.event_name == 'push'
+        run: |
+          echo '//npm.coremedia.io/:_authToken=${NPM_AUTH_TOKEN}' > .npmrc
+          pnpm publishall -- --registry=https://npm.coremedia.io --no-git-checks --tag next
+          git reset --hard
+      # Publishes a release with tag "latest"
+      - name: Publish Release
+        if: github.event_name == 'workflow_dispatch'
         run: |
           echo '//npm.coremedia.io/:_authToken=${NPM_AUTH_TOKEN}' > .npmrc
           pnpm publishall -- --registry=https://npm.coremedia.io --no-git-checks


### PR DESCRIPTION
Until now our packages are published to the npm repository with tag "latest".
This means customer get the suggestion to update there package to the "latest" versions.
We have to prevent this for prereleases (pull requests and rc builds) so customers do not accidentially update to a prerelease.

Pullrequest builds will now get the tag "pullrequest", rc "next" and releases will stay "latest".