### PR TITLE
CI: Improve unpublish and provide a listing of all packages with versions.

### DIFF
--- a/.github/workflows/package-listing.yml
+++ b/.github/workflows/package-listing.yml
@@ -1,0 +1,28 @@
+name: List packages
+on:
+  workflow_dispatch:
+jobs:
+  build:
+    name: Package listing
+    env:
+      NPM_CONFIG_@coremedia:registry: 'https://npm.coremedia.io'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Resolve NPM_AUTH_TOKEN
+        run: |
+          NPM_AUTH_TOKEN=$(curl -s -H "Accept: application/json" -H "Content-Type:application/json" -X PUT --data '{"name": "${{ secrets.CM_NPM_USER }}", "password": "${{ secrets.CM_NPM_PASSWORD }}"}' https://npm.coremedia.io/-/user/org.couchdb.user:${{ secrets.CM_NPM_USER }} | jq -r .token)
+          echo "::add-mask::$NPM_AUTH_TOKEN"
+          echo "NPM_CONFIG_//npm.coremedia.io/:_authToken=$NPM_AUTH_TOKEN" >> $GITHUB_ENV
+          echo "NPM_AUTH_TOKEN=$NPM_AUTH_TOKEN" >> $GITHUB_ENV
+          echo '//npm.coremedia.io/:_authToken=${NPM_AUTH_TOKEN}' > .npmrc
+      - name: List all @coremedia/ckeditor5 packages with all versions
+        run: |
+          cmcke5packages=$(npm search "@coremedia/ckeditor" --json --registry https://npm.coremedia.io)
+          for i in $(jq -r ".[].name" <(echo "$cmcke5packages"))
+          do
+            echo $i
+            npm view "$i" versions --registry https://npm.coremedia.io
+          done
+

--- a/.github/workflows/unpublish.yml
+++ b/.github/workflows/unpublish.yml
@@ -24,13 +24,15 @@ jobs:
       - name: Unpublish release
         run: |
           version=${{ github.event.inputs.version }}
-          npm unpublish @coremedia/ckeditor5-logging@$version
-          npm unpublish @coremedia/ckeditor5-coremedia-studio-integration-mock@$version
-          npm unpublish @coremedia/ckeditor5-coremedia-studio-integration@$version
-          npm unpublish @coremedia/ckeditor5-studio-essentials@$version
-          npm unpublish @coremedia/ckeditor5-coremedia-general-richtext-support@$version
-          npm unpublish @coremedia/ckeditor5-coremedia-richtext@$version
-          npm unpublish @coremedia/ckeditor5-dataprocessor-support@$version
-          npm unpublish @coremedia/ckeditor5-coremedia-link@$version
-          npm unpublish @coremedia/ckeditor5-symbol-on-paste-mapper@$version
-          npm unpublish @coremedia/types-ckeditor__ckeditor5-editor-classic@$version
+          if [[ $version != *"-"* ]]; then
+            echo "$version is a release version. Only prerelease versions can be unpublished"
+            exit 0
+          fi
+
+          cmcke5packages=$(npm search "@coremedia/ckeditor" --json --registry https://npm.coremedia.io)
+          echo "$version"
+          echo "$cmcke5packages"
+          for i in $(jq -r ".[].name" <(echo "$cmcke5packages"))
+          do
+            npm unpublish $i@$version
+          done


### PR DESCRIPTION
Improves the maintenance of prerelease versions.
To find out which versions for which package with the scope @coremedia/ckeditor5 is currently deployed a new workflow has been introduced. This workflow can be used to determine which versions have to be unpublished.
The unpublishing workflow has been improved by trying to unpublish a given version for each @coremedia/ckeditor5 package which exist. As it doesn't matter if the version to unpublish exist this is totally valid.