### PR TITLE
CI: Add types to the housekeeping

### DIFF
--- a/.github/workflows/package-listing.yml
+++ b/.github/workflows/package-listing.yml
@@ -25,4 +25,12 @@ jobs:
             echo $i
             npm view "$i" versions --registry https://npm.coremedia.io
           done
+      - name: List all @coremedia/types-ckeditor__ packages with all versions
+        run: |
+          cmcke5packages=$(npm search "@coremedia/types-ckeditor__" --json --registry https://npm.coremedia.io)
+          for i in $(jq -r ".[].name" <(echo "$cmcke5packages"))
+          do
+            echo $i
+            npm view "$i" versions --registry https://npm.coremedia.io
+          done
 

--- a/types/ckeditor__ckeditor5-editor-classic/package.json
+++ b/types/ckeditor__ckeditor5-editor-classic/package.json
@@ -2,6 +2,7 @@
   "name": "@coremedia/types-ckeditor__ckeditor5-editor-classic",
   "version": "2.0.1-rc.2",
   "license": "Apache-2.0",
+  "private": true,
   "dependencies": {
     "@coremedia/types-ckeditor__ckeditor5-core": "2.0.1-rc.2"
   },


### PR DESCRIPTION
Earlier on a package listing and unpublish has been introduced for the coremedia/ckeditor packages but not for the types.
