### PR TITLE
Fix: Reenable Typedoc

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -70,6 +70,8 @@ jobs:
         run: pnpm lint
       - name: Test
         run: pnpm jest
+      - name: TypeDoc
+        run: pnpm doc
       - name: Publish prerelease
         if: github.event_name == 'workflow_dispatch'
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,6 +109,8 @@ jobs:
         run: pnpm lint
       - name: Test
         run: pnpm jest
+      - name: TypeDoc
+        run: pnpm doc
       - name: Install for Production
         run: pnpm install --production
       # Publishes a release candidate with tag "next".

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@coremedia/set-version": "1.1.1"
   },
   "devDependencies": {
+    "@types/jest": "^27.5.1",
     "rimraf": "^3.0.2",
     "typedoc": "^0.22.17",
     "typedoc-plugin-merge-modules": "^3.1.0",

--- a/packages/ckeditor5-coremedia-richtext/__tests__/DataDrivenTests.ts
+++ b/packages/ckeditor5-coremedia-richtext/__tests__/DataDrivenTests.ts
@@ -6,6 +6,7 @@ import { parseXml, silenced } from "./Utils";
 
 jest.mock("@ckeditor/ckeditor5-core/src/editor/editor");
 
+//@ts-expect-error
 const MOCK_EDITOR = new Editor();
 
 /**

--- a/packages/ckeditor5-coremedia-richtext/__tests__/ToDataProcessor.test.ts
+++ b/packages/ckeditor5-coremedia-richtext/__tests__/ToDataProcessor.test.ts
@@ -47,6 +47,7 @@ function fib(idx: number, memo?: Map<number, number>): number {
   return result;
 }
 
+//@ts-expect-error
 const MOCK_EDITOR = new Editor();
 const PARSER = new DOMParser();
 

--- a/packages/ckeditor5-dataprocessor-support/__tests__/ElementProxy.test.ts
+++ b/packages/ckeditor5-dataprocessor-support/__tests__/ElementProxy.test.ts
@@ -5,6 +5,7 @@ import Editor from "@ckeditor/ckeditor5-core/src/editor/editor";
 
 jest.mock("@ckeditor/ckeditor5-core/src/editor/editor");
 
+//@ts-expect-error
 const MOCK_EDITOR = new Editor();
 
 /*

--- a/packages/ckeditor5-dataprocessor-support/__tests__/HtmlFilter.test.ts
+++ b/packages/ckeditor5-dataprocessor-support/__tests__/HtmlFilter.test.ts
@@ -6,6 +6,7 @@ import Editor from "@ckeditor/ckeditor5-core/src/editor/editor";
 
 jest.mock("@ckeditor/ckeditor5-core/src/editor/editor");
 
+//@ts-expect-error
 const MOCK_EDITOR = new Editor();
 
 /**

--- a/packages/ckeditor5-dataprocessor-support/__tests__/Rules.test.ts
+++ b/packages/ckeditor5-dataprocessor-support/__tests__/Rules.test.ts
@@ -15,6 +15,7 @@ jest.mock("@ckeditor/ckeditor5-core/src/editor/editor");
  */
 const TEST_SELECTOR = "";
 
+//@ts-expect-error
 const MOCK_EDITOR = new Editor();
 
 const parser = new DOMParser();

--- a/packages/ckeditor5-dataprocessor-support/__tests__/TextProxy.test.ts
+++ b/packages/ckeditor5-dataprocessor-support/__tests__/TextProxy.test.ts
@@ -4,6 +4,7 @@ import TextProxy, { TextFilterRule } from "../src/TextProxy";
 
 jest.mock("@ckeditor/ckeditor5-core/src/editor/editor");
 
+//@ts-expect-error
 const MOCK_EDITOR = new Editor();
 const SERIALIZER = new XMLSerializer();
 const PARSER = new DOMParser();

--- a/packages/ckeditor5-font-mapper/src/FontMappingRegistry.ts
+++ b/packages/ckeditor5-font-mapper/src/FontMappingRegistry.ts
@@ -1,4 +1,4 @@
-import { FontMapperConfigEntry } from "FontMapper";
+import { FontMapperConfigEntry } from "./FontMapper";
 import { configToMap } from "./ConfigToMapUtil";
 import { FontMapping } from "./FontMapping";
 import { symbolFontMap } from "./SymbolFontMap";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,7 @@ importers:
   .:
     specifiers:
       '@coremedia/set-version': 1.1.1
+      '@types/jest': ^27.5.1
       rimraf: ^3.0.2
       typedoc: ^0.22.17
       typedoc-plugin-merge-modules: ^3.1.0
@@ -12,6 +13,7 @@ importers:
     dependencies:
       '@coremedia/set-version': 1.1.1
     devDependencies:
+      '@types/jest': 27.5.2
       rimraf: 3.0.2
       typedoc: 0.22.17_typescript@4.7.2
       typedoc-plugin-merge-modules: 3.1.0_typedoc@0.22.17

--- a/typedoc-tsconfig.json
+++ b/typedoc-tsconfig.json
@@ -25,6 +25,9 @@
       "@coremedia/ckeditor5-coremedia-studio-integration/*": [
         "./packages/ckeditor5-coremedia-studio-integration/src/*"
       ],
+      "@coremedia/ckeditor5-data-normalization/*": [
+        "./packages/ckeditor5-data-normalization/src/*"
+      ],
       "@coremedia/ckeditor5-coremedia-studio-integration-mock/*": [
         "./packages/ckeditor5-coremedia-studio-integration-mock/src/*"
       ],
@@ -34,10 +37,11 @@
       "@coremedia/ckeditor5-logging/*": [
         "./packages/ckeditor5-logging/src/*"
       ],
-      "@coremedia/ckeditor5-symbol-on-paste-mapper/*": [
-        "./packages/ckeditor5-symbol-on-paste-mapper/src/*"
+      "@coremedia/ckeditor5-font-mapper/*": [
+        "./packages/ckeditor5-font-mapper/src/*"
       ]
     }
   },
+  "exclude": ["itest", "app"],
   "extends": "./tsconfig.json"
 }

--- a/typedoc.json
+++ b/typedoc.json
@@ -12,6 +12,7 @@
     "./packages/ckeditor5-coremedia-studio-integration/src/index-doc.ts",
     "./packages/ckeditor5-coremedia-studio-integration-mock/src/index-doc.ts",
     "./packages/ckeditor5-dataprocessor-support/src/index-doc.ts",
+    "./packages/ckeditor5-data-normalization/src/index-doc.ts",
     "./packages/ckeditor5-logging/src/index-doc.ts",
     "./packages/ckeditor5-font-mapper/src/index-doc.ts"
   ],


### PR DESCRIPTION
This PR fixes TypeDoc in this repository.
It also adds a TypeDoc step to the release and pre-release github workflows.
TypeDoc was broken for several reasons:

- Missing path dependencies for new packages in the typedoc-tsconfig
- TS Issues in the itest package (got excluded)
- Some minor TS issues which did not prevent building the packages, but resulted in TypeDoc Errors