### PR TITLE
Fix: Content Link Issues

### DIFF
--- a/packages/ckeditor5-coremedia-link/src/contentlink/ui/ContentLinkActionsViewExtension.ts
+++ b/packages/ckeditor5-coremedia-link/src/contentlink/ui/ContentLinkActionsViewExtension.ts
@@ -105,7 +105,10 @@ class ContentLinkActionsViewExtension extends Plugin {
         // we need to hide the balloon for the Studio environment
         // otherwise a new tab would open and the balloon would still be displayed
         ifPlugin(this.editor, ContextualBalloon).then((balloon) => {
-          balloon.view.hide();
+          if (balloon.visibleView) {
+            // it is not sufficient to just hide the visibleView, we need to remove it
+            balloon.remove(balloon.visibleView);
+          }
         });
         openInTab(contentLinkView.uriPath);
       }

--- a/packages/ckeditor5-coremedia-link/src/contentlink/ui/ContentLinkActionsViewExtension.ts
+++ b/packages/ckeditor5-coremedia-link/src/contentlink/ui/ContentLinkActionsViewExtension.ts
@@ -52,12 +52,16 @@ class ContentLinkActionsViewExtension extends Plugin {
      */
     linkUI.actionsView.on("change:contentUriPath", (evt) => {
       const { source } = evt;
+      // @ts-expect-error Bad Typing: DefinitelyTyped/DefinitelyTyped#60975
+      const formView: LinkFormView = linkUI.formView;
+
       if (!hasContentUriPath(source)) {
+        // set visibility of url and content field
+        showContentLinkField(formView, false);
+        showContentLinkField(linkUI.actionsView, false);
         return;
       }
 
-      // @ts-expect-error Bad Typing: DefinitelyTyped/DefinitelyTyped#60975
-      const formView: LinkFormView = linkUI.formView;
       const { contentUriPath: value } = source;
 
       // content link value has changed. set urlInputView accordingly

--- a/packages/ckeditor5-coremedia-link/src/contentlink/ui/ContentLinkActionsViewExtension.ts
+++ b/packages/ckeditor5-coremedia-link/src/contentlink/ui/ContentLinkActionsViewExtension.ts
@@ -11,6 +11,8 @@ import { LINK_COMMAND_NAME } from "../../link/Constants";
 import { Command } from "@ckeditor/ckeditor5-core";
 import LinkFormView from "@ckeditor/ckeditor5-link/src/ui/linkformview";
 import { hasContentUriPath } from "./ViewExtensions";
+import { ContextualBalloon } from "@ckeditor/ckeditor5-ui";
+import { ifPlugin } from "@coremedia/ckeditor5-core-common/Plugins";
 
 /**
  * Extends the action view for Content link display. This includes:
@@ -100,6 +102,11 @@ class ContentLinkActionsViewExtension extends Plugin {
 
     contentLinkView.on("contentClick", () => {
       if (contentLinkView.uriPath) {
+        // we need to hide the balloon for the Studio environment
+        // otherwise a new tab would open and the balloon would still be displayed
+        ifPlugin(this.editor, ContextualBalloon).then((balloon) => {
+          balloon.view.hide();
+        });
         openInTab(contentLinkView.uriPath);
       }
     });

--- a/packages/ckeditor5-coremedia-link/src/linktarget/LinkTarget.ts
+++ b/packages/ckeditor5-coremedia-link/src/linktarget/LinkTarget.ts
@@ -1,7 +1,6 @@
 import Plugin from "@ckeditor/ckeditor5-core/src/plugin";
 import LinkTargetModelView from "./LinkTargetModelView";
 import Link from "@ckeditor/ckeditor5-link/src/link";
-import Editor from "@ckeditor/ckeditor5-core/src/editor/editor";
 import LinkTargetActionsViewExtension from "./LinkTargetActionsViewExtension";
 import "../lang/linktarget";
 /**


### PR DESCRIPTION
This PR fixes 2 issues with content links:

1. Switching between external and internal links now works properly.
Before, there was an issue while opening a link balloon containing content links and external links.
The balloon would not update correctly if an external link was displayed after showing a content link.

2. Clicking on a content link now closes the contextual balloon.
The previous behavior caused an issue in CoreMedia Studio. The balloon would not lose focus, but clicking on the
link triggers another content tab to open. Since the balloon is not part of the editor's DOM tree, it would then still be visible.