### PR TITLE
Link-Target Feature: Respect Read-Only State of Editor

### DIFF
--- a/app/sample/index.html
+++ b/app/sample/index.html
@@ -52,7 +52,7 @@
   </div>
   <div class="centered">
     <div>
-      <button id="readOnlyMode">Enable Read-Only-Mode</button>
+      <button id="readOnlyMode" title="Delay Modifiers: Ctrl/Cmd: 10s, Shift: 60s, Ctrl/Cmd+Shift: 120s">Enable Read-Only-Mode</button>
       <button id="previewButton">Show XML Preview</button>
       <button id="dragExamplesButton">Show drag examples</button>
     </div>

--- a/app/sample/index.html
+++ b/app/sample/index.html
@@ -52,6 +52,7 @@
   </div>
   <div class="centered">
     <div>
+      <button id="readOnlyMode">Enable Read-Only-Mode</button>
       <button id="previewButton">Show XML Preview</button>
       <button id="dragExamplesButton">Show drag examples</button>
     </div>

--- a/app/src/ckeditor.js
+++ b/app/src/ckeditor.js
@@ -37,6 +37,7 @@ import CoreMediaFontMapper from '@coremedia/ckeditor5-font-mapper/FontMapper';
 import MockStudioIntegration from "@coremedia/ckeditor5-coremedia-studio-integration-mock/MockStudioIntegration";
 
 import {setupPreview, updatePreview} from './preview'
+import {initReadOnlyMode} from './readOnlySupport'
 import {initExamples} from './example-data'
 import CoreMediaStudioEssentials, {
   COREMEDIA_RICHTEXT_CONFIG_KEY,
@@ -298,6 +299,7 @@ ClassicEditor.create(document.querySelector('.editor'), {
   if (differencing) {
     differencing.activateDifferencing();
   }
+  initReadOnlyMode(newEditor);
   initExamples(newEditor);
   initDragExamples(newEditor);
   editor = newEditor;

--- a/app/src/readOnlySupport.js
+++ b/app/src/readOnlySupport.js
@@ -11,25 +11,50 @@ const initReadOnlyMode = (editor) => {
     return;
   }
 
+  toggleButton.dataset.currentState = "read-write";
+
   const setLabel = (label) => toggleButton.textContent = label;
 
   const enableReadOnly = () => {
+    toggleButton.dataset.currentState = "read-only";
     editor.enableReadOnlyMode(READ_ONY_MODE_ID);
     setLabel(DISABLE_BTN_LABEL);
   };
 
   const disableReadOnly = () => {
+    toggleButton.dataset.currentState = "read-write";
     editor.disableReadOnlyMode(READ_ONY_MODE_ID);
     setLabel(ENABLE_BTN_LABEL);
   };
 
   // Naive check, but should be ok. We cannot ask CKEditor directly, if WE
   // are responsible for read-only state.
-  const isReadOnly = () => toggleButton.textContent === DISABLE_BTN_LABEL;
+  const isReadOnly = () => toggleButton.dataset.currentState === "read-only";
 
   setLabel(ENABLE_BTN_LABEL);
 
-  toggleButton.addEventListener("click", () => isReadOnly() ? disableReadOnly() : enableReadOnly());
+  let currentToggleDelay = undefined;
+
+  const toggleState = (countDownSeconds) => {
+    if (countDownSeconds > 0) {
+      setLabel(`Toggling Read-Only-Mode in ${countDownSeconds} s...`);
+      currentToggleDelay = setTimeout(toggleState, 1000, countDownSeconds - 1);
+    } else {
+      isReadOnly() ? disableReadOnly() : enableReadOnly();
+    }
+  };
+
+  toggleButton.addEventListener("click", (evt) => {
+    clearTimeout(currentToggleDelay);
+    let countDownSeconds = 0;
+    const ctrlOrCommandKey = evt.ctrlKey || evt.metaKey;
+    if (evt.shiftKey) {
+      countDownSeconds = ctrlOrCommandKey ? 120 : 60;
+    } else if (ctrlOrCommandKey) {
+      countDownSeconds = 10;
+    }
+    toggleState(countDownSeconds);
+  });
 };
 
 export {

--- a/app/src/readOnlySupport.js
+++ b/app/src/readOnlySupport.js
@@ -1,0 +1,37 @@
+const READ_ONLY_MODE_BTN_ID = "readOnlyMode";
+const READ_ONY_MODE_ID = "exampleApplicationReadOnlyMode";
+const ENABLE_BTN_LABEL = "Enable Read-Only-Mode";
+const DISABLE_BTN_LABEL = "Disable Read-Only-Mode";
+
+const initReadOnlyMode = (editor) => {
+  const toggleButton = document.querySelector(`#${READ_ONLY_MODE_BTN_ID}`);
+
+  if (!toggleButton) {
+    console.error("Failed initializing read-only mode toggle, as required button is not available.");
+    return;
+  }
+
+  const setLabel = (label) => toggleButton.textContent = label;
+
+  const enableReadOnly = () => {
+    editor.enableReadOnlyMode(READ_ONY_MODE_ID);
+    setLabel(DISABLE_BTN_LABEL);
+  };
+
+  const disableReadOnly = () => {
+    editor.disableReadOnlyMode(READ_ONY_MODE_ID);
+    setLabel(ENABLE_BTN_LABEL);
+  };
+
+  // Naive check, but should be ok. We cannot ask CKEditor directly, if WE
+  // are responsible for read-only state.
+  const isReadOnly = () => toggleButton.textContent === DISABLE_BTN_LABEL;
+
+  setLabel(ENABLE_BTN_LABEL);
+
+  toggleButton.addEventListener("click", () => isReadOnly() ? disableReadOnly() : enableReadOnly());
+};
+
+export {
+  initReadOnlyMode
+}

--- a/packages/ckeditor5-core-common/src/Commands.ts
+++ b/packages/ckeditor5-core-common/src/Commands.ts
@@ -2,7 +2,6 @@ import Editor from "@ckeditor/ckeditor5-core/src/editor/editor";
 import Logger from "@coremedia/ckeditor5-logging/logging/Logger";
 import LoggerProvider from "@coremedia/ckeditor5-logging/logging/LoggerProvider";
 import Command from "@ckeditor/ckeditor5-core/src/command";
-import { PluginNotFoundErrorHandler } from "./Plugins";
 
 const commandsLogger: Logger = LoggerProvider.getLogger("Commands");
 

--- a/packages/ckeditor5-coremedia-link/src/linktarget/LinkTargetActionsViewExtension.ts
+++ b/packages/ckeditor5-coremedia-link/src/linktarget/LinkTargetActionsViewExtension.ts
@@ -66,7 +66,7 @@ class LinkTargetActionsViewExtension extends Plugin {
     // convert button configurations to buttonView instances
     const buttons = linkTargetDefinitions.map((buttonConfig) => {
       if (buttonConfig.name === OTHER_TARGET_NAME) {
-        return this.#createTargetOtherButton(linkTargetCommand);
+        return this.#createTargetOtherButton();
       } else {
         return this.#createTargetButton(linkUI.editor.locale, buttonConfig, linkTargetCommand);
       }
@@ -98,14 +98,10 @@ class LinkTargetActionsViewExtension extends Plugin {
   /**
    * Creates a button for `other` behavior, which is, that you can enter any
    * custom target value in an extra dialog.
-   *
-   * @param linkTargetCommand - command the enabled state is bound to
    */
-  #createTargetOtherButton(linkTargetCommand: Command) {
+  #createTargetOtherButton() {
     const { ui } = requireEditorWithUI(this.editor);
-    const view = <ButtonView>ui.componentFactory.create(CustomLinkTargetUI.customTargetButtonName);
-    view.bind("isEnabled").to(linkTargetCommand);
-    return view;
+    return <ButtonView>ui.componentFactory.create(CustomLinkTargetUI.customTargetButtonName);
   }
 
   /**
@@ -160,9 +156,13 @@ class LinkTargetActionsViewExtension extends Plugin {
    * @param buttons - the buttons to add in the given order
    */
   #addButtons(actionsView: LinkActionsView, buttons: View[]): void {
+    const viewElement = actionsView.element;
+    if (!viewElement) {
+      return;
+    }
     buttons.forEach((button) => {
-      // @ts-expect-error TODO Missing null-Handling
-      actionsView.element.insertBefore(button.element, actionsView.unlinkButtonView.element);
+      // @ts-expect-error Possibly wrong typing for insertBefore?
+      viewElement.insertBefore(button.element, actionsView.unlinkButtonView.element);
     });
   }
 }

--- a/packages/ckeditor5-coremedia-link/src/linktarget/LinkTargetActionsViewExtension.ts
+++ b/packages/ckeditor5-coremedia-link/src/linktarget/LinkTargetActionsViewExtension.ts
@@ -14,6 +14,7 @@ import View from "@ckeditor/ckeditor5-ui/src/view";
 import "../../theme/linktargetactionsviewextension.css";
 import Locale from "@ckeditor/ckeditor5-utils/src/locale";
 import { requireEditorWithUI } from "@coremedia/ckeditor5-core-common/Editors";
+import { ifCommand } from "@coremedia/ckeditor5-core-common/Commands";
 
 /**
  * Extends the action view of the linkUI plugin for link target display. This includes:
@@ -33,7 +34,7 @@ class LinkTargetActionsViewExtension extends Plugin {
 
   static readonly requires = [LinkUI, CustomLinkTargetUI];
 
-  init(): Promise<void> | void {
+  async init(): Promise<void> {
     const logger = LinkTargetActionsViewExtension.#logger;
     const startTimestamp = performance.now();
 
@@ -42,7 +43,7 @@ class LinkTargetActionsViewExtension extends Plugin {
     const editor = this.editor;
     const linkUI: LinkUI = <LinkUI>editor.plugins.get(LinkUI);
 
-    this.#extendView(linkUI);
+    await this.#extendView(linkUI);
 
     logger.debug(
       `Initialized ${LinkTargetActionsViewExtension.pluginName} within ${performance.now() - startTimestamp} ms.`
@@ -57,16 +58,15 @@ class LinkTargetActionsViewExtension extends Plugin {
    *
    * @param linkUI - the linkUI plugin
    */
-  #extendView(linkUI: LinkUI): void {
+  async #extendView(linkUI: LinkUI): Promise<void> {
     const actionsView: LinkActionsView = linkUI.actionsView;
-    const linkTargetCommand = this.editor.commands.get("linkTarget");
+    const linkTargetCommand = await ifCommand(this.editor, "linkTarget");
     const linkTargetDefinitions = parseLinkTargetConfig(this.editor.config);
 
     // convert button configurations to buttonView instances
     const buttons = linkTargetDefinitions.map((buttonConfig) => {
       if (buttonConfig.name === OTHER_TARGET_NAME) {
-        const { ui } = requireEditorWithUI(this.editor);
-        return <ButtonView>ui.componentFactory.create(CustomLinkTargetUI.customTargetButtonName);
+        return this.#createTargetOtherButton(linkTargetCommand);
       } else {
         return this.#createTargetButton(linkUI.editor.locale, buttonConfig, linkTargetCommand);
       }
@@ -96,6 +96,19 @@ class LinkTargetActionsViewExtension extends Plugin {
   }
 
   /**
+   * Creates a button for `other` behavior, which is, that you can enter any
+   * custom target value in an extra dialog.
+   *
+   * @param linkTargetCommand - command the enabled state is bound to
+   */
+  #createTargetOtherButton(linkTargetCommand: Command) {
+    const { ui } = requireEditorWithUI(this.editor);
+    const view = <ButtonView>ui.componentFactory.create(CustomLinkTargetUI.customTargetButtonName);
+    view.bind("isEnabled").to(linkTargetCommand);
+    return view;
+  }
+
+  /**
    * Creates and returns an instance of a buttonView for link target representation.
    * The buttons are bound to {@link LinkTargetCommand} to set the target on execute
    * and toggle their state accordingly.
@@ -110,7 +123,7 @@ class LinkTargetActionsViewExtension extends Plugin {
   #createTargetButton(
     locale: Locale,
     buttonConfig: LinkTargetOptionDefinition,
-    linkTargetCommand: Command | undefined
+    linkTargetCommand: Command
   ): ButtonView {
     const view = new ButtonView();
     view.set({
@@ -123,12 +136,15 @@ class LinkTargetActionsViewExtension extends Plugin {
     });
 
     // Corner Case: `_self` is also on, if no target is set yet.
-    view.bind("isOn").to(
-      // @ts-expect-error TODO Check undefined handling
-      linkTargetCommand,
-      "value",
-      (value: string) => value === buttonConfig.name || (value === undefined && buttonConfig.name === "_self")
-    );
+    view
+      .bind("isOn")
+      .to(
+        linkTargetCommand,
+        "value",
+        (value: unknown) => value === buttonConfig.name || (value === undefined && buttonConfig.name === "_self")
+      );
+
+    view.bind("isEnabled").to(linkTargetCommand);
 
     view.on("execute", () => {
       linkTargetCommand?.execute(buttonConfig.name);

--- a/packages/ckeditor5-coremedia-link/src/linktarget/ui/CustomLinkTargetInputFormView.ts
+++ b/packages/ckeditor5-coremedia-link/src/linktarget/ui/CustomLinkTargetInputFormView.ts
@@ -13,6 +13,7 @@ import submitHandler from "@ckeditor/ckeditor5-ui/src/bindings/submithandler";
 import "@ckeditor/ckeditor5-ui/theme/components/responsive-form/responsiveform.css";
 import "../../../theme/customlinktargetform.css";
 import { icons } from "@ckeditor/ckeditor5-core";
+import Command from "@ckeditor/ckeditor5-core/src/command";
 
 /**
  * The CustomLinkTargetInputFormView class is a basic view with a few child items.
@@ -33,7 +34,7 @@ export default class CustomLinkTargetInputFormView extends View {
   declare enableCssTransitions: () => void;
   declare disableCssTransitions: () => void;
 
-  constructor(locale?: Locale) {
+  constructor(linkTargetCommand: Command, locale?: Locale) {
     super(locale);
 
     const t = this.locale?.t;
@@ -62,6 +63,10 @@ export default class CustomLinkTargetInputFormView extends View {
      */
     this.saveButtonView = this.#createButton(t?.("Save") || "Save", icons.check, "ck-button-save");
     this.saveButtonView.type = "submit";
+
+    // Required for concurrent editing: If we are at editing a custom target
+    // and content changes to read-only we must not be able to save anymore.
+    this.saveButtonView.bind("isEnabled").to(linkTargetCommand);
 
     /**
      * A button used to cancel the form.


### PR DESCRIPTION
The link-target feature ignored the read-only state of the editor:

![Read-Only Link-Target Selection](https://user-images.githubusercontent.com/71911/185925161-7dec2ddb-f5ff-4990-aa72-4fef7339bc82.png)

### 🩹 The Fix

This PR applies the following fixes:

* **Buttons in Actions View are Disabled**

  ![read-only-actions-view](https://user-images.githubusercontent.com/71911/186132063-c420ddb9-c9d6-445d-b4e8-517696441591.png)

* **Save Button in Form View is Disabled**

  * Disabled State:

    ![read-only-form-view](https://user-images.githubusercontent.com/71911/186132273-d18ac27d-586f-4396-9b94-948e2384a1d6.png)

  * Enabled State:

    ![read-write-form-view](https://user-images.githubusercontent.com/71911/186132505-d6d33790-ce87-48eb-8291-e4163bd73cd9.png)

  This is the same behavior as for CKEditor 5 Link Feature, when editing a link URL, while the editor becomes disabled. Thus, only the Save button becomes disabled, while the input field as well as the cancel button stay enabled.

### 🧪 Testing

The example application now has a read-only toggle button, similar to the example as provided by [CKEditor 5](https://ckeditor.com/docs/ckeditor5/35.0.1/features/read-only.html):

![read-only-toggle](https://user-images.githubusercontent.com/71911/186133552-37df34bb-6a6c-4a25-bbb8-cef6b6367df5.png)

As can be seen in the screenshot, a click accepts modifier keys to trigger state switch after a given timeout:

* Ctrl/Cmd+Click: 10 seconds delay
* Shift+Click: 60 seconds delay
* Ctrl/Cmd+Shift+Click: 120 seconds delay

This may be used for testing behavior for triggered read-only state by remote actions (in context of CoreMedia Studio: check out by other user).