### PR TITLE
Differencing: Get Rid of False-Positive Newline Added

### DIFF
--- a/app/sample/styles.css
+++ b/app/sample/styles.css
@@ -276,14 +276,14 @@ xdiff\:span[xdiff\:class="diff-html-added"] {
   text-decoration: underline;
 }
 /* Represents inserted newline. */
-p > xdiff\:span[xdiff\:class="diff-html-added"]:empty::before {
+p > xdiff\:br[xdiff\:class="diff-html-added"]::before {
   content: url("data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciCiAgICAgeD0iMHB4IgogICAgIHk9IjBweCIKICAgICB3aWR0aD0iMTZweCIKICAgICBoZWlnaHQ9IjE2cHgiCiAgICAgdmlld0JveD0iMCAwIDE2IDE2Ij4KPHBvbHlnb24gZmlsbD0icmdiKDkyLCAxNjAsIDYzKSIgcG9pbnRzPSIxMSw0IDExLDYgMTMsNiAxMyw5IDUsOSA1LDYgMSwxMCA1LDE0IDUsMTEgMTUsMTEgMTUsOSAxNSw2IDE1LDQiLz4KPC9zdmc+Cg==");
   height: 16px;
   position: absolute;
   margin-left: 3px;
 }
 /* Represents removed newline. */
-p > xdiff\:span[xdiff\:class="diff-html-removed"]:empty::before {
+p > xdiff\:br[xdiff\:class="diff-html-removed"]::before {
   content: url("data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciCiAgICAgeD0iMHB4IgogICAgIHk9IjBweCIKICAgICB3aWR0aD0iMTZweCIKICAgICBoZWlnaHQ9IjE2cHgiCiAgICAgdmlld0JveD0iMCAwIDE2IDE2Ij4KPHBvbHlnb24gZmlsbD0icmdiKDE5NiwgMTksIDE5KSIgcG9pbnRzPSIxMSw0IDExLDYgMTMsNiAxMyw5IDUsOSA1LDYgMSwxMCA1LDE0IDUsMTEgMTUsMTEgMTUsOSAxNSw2IDE1LDQiLz4KPC9zdmc+Cg==");
   height: 16px;
   position: absolute;

--- a/packages/ckeditor5-coremedia-differencing/src/Differencing.ts
+++ b/packages/ckeditor5-coremedia-differencing/src/Differencing.ts
@@ -81,7 +81,7 @@ export default class Differencing extends Plugin {
     conversion.for("downcast").elementToElement({
       ...XDIFF_SPAN_ELEMENT_CONFIG,
       view: (modelElement, { writer }) => {
-        if (modelElement.childCount === 0) {
+        if (modelElement.isEmpty) {
           /*
            * Especially for CSS rules to apply, it is important to keep the
            * empty state here. Not explicitly stating, that this element

--- a/packages/ckeditor5-coremedia-differencing/src/Differencing.ts
+++ b/packages/ckeditor5-coremedia-differencing/src/Differencing.ts
@@ -1,7 +1,7 @@
 import Plugin from "@ckeditor/ckeditor5-core/src/plugin";
 import { ImageElementSupport } from "./integrations/Image";
 import { HtmlImageElementSupport } from "./integrations/HtmlSupportImage";
-import { XDIFF_ATTRIBUTES, XDIFF_SPAN_ELEMENT_CONFIG } from "./Xdiff";
+import { XDIFF_ATTRIBUTES, XDIFF_BREAK_ELEMENT_CONFIG, XDIFF_SPAN_ELEMENT_CONFIG } from "./Xdiff";
 import { reportInitializationProgress } from "@coremedia/ckeditor5-core-common/Plugins";
 import Logger from "@coremedia/ckeditor5-logging/logging/Logger";
 import LoggerProvider from "@coremedia/ckeditor5-logging/logging/LoggerProvider";
@@ -63,14 +63,23 @@ export default class Differencing extends Plugin {
     const { model, conversion } = editor;
     const { schema } = model;
 
-    schema.register("xdiff-span", {
-      allowIn: ["$block", "$container"],
-      allowChildren: ["$text", "$block", "$container"],
+    schema.register("xdiffSpan", {
+      allowWhere: "$inlineObject",
+      allowContentOf: ["$block", "$container"],
+      allowAttributes: Object.values(XDIFF_ATTRIBUTES),
+      isInline: true,
+    });
+
+    schema.register("xdiffBreak", {
+      allowWhere: "softBreak",
+      allowChildren: [],
       allowAttributes: Object.values(XDIFF_ATTRIBUTES),
       isInline: true,
     });
 
     conversion.for("upcast").elementToElement(XDIFF_SPAN_ELEMENT_CONFIG);
+    conversion.for("upcast").elementToElement(XDIFF_BREAK_ELEMENT_CONFIG);
+
     /*
      * **dataDowncast:** We also downcast back to data view, relying on other
      * mechanisms (like data-processing), that these changes are not written
@@ -78,25 +87,13 @@ export default class Differencing extends Plugin {
      * data, which are not meant to be stored on server again.
      */
 
+    conversion.for("downcast").elementToElement(XDIFF_SPAN_ELEMENT_CONFIG);
+
     conversion.for("downcast").elementToElement({
-      ...XDIFF_SPAN_ELEMENT_CONFIG,
-      view: (modelElement, { writer }) => {
-        if (modelElement.isEmpty) {
-          /*
-           * Especially for CSS rules to apply, it is important to keep the
-           * empty state here. Not explicitly stating, that this element
-           * is considered empty, would add a filler element inside, like:
-           *
-           * ```html
-           * <br data-cke-filler="true">
-           * ```
-           *
-           * which again is hard to apply CSS styles to.
-           */
-          return writer.createEmptyElement(XDIFF_SPAN_ELEMENT_CONFIG.view);
-        }
-        return writer.createContainerElement(XDIFF_SPAN_ELEMENT_CONFIG.view);
-      },
+      ...XDIFF_BREAK_ELEMENT_CONFIG,
+      // DevNote: Empty Element prevents, for example, filler elements to be
+      // added.
+      view: (modelElement, { writer }) => writer.createEmptyElement(XDIFF_BREAK_ELEMENT_CONFIG.view),
     });
 
     /*

--- a/packages/ckeditor5-coremedia-differencing/src/Xdiff.ts
+++ b/packages/ckeditor5-coremedia-differencing/src/Xdiff.ts
@@ -40,5 +40,18 @@ export const XDIFF_SPAN_ELEMENT_CONFIG: {
   model: string;
 } = {
   view: "xdiff:span",
-  model: "xdiff-span",
+  model: "xdiffSpan",
+};
+
+/**
+ * Artificial element added on data-processing to mark added, removed, changed
+ * or conflicting newlines. Originally received from server side differencing
+ * as `<xdiff:span/>`, i.e., without any content.
+ */
+export const XDIFF_BREAK_ELEMENT_CONFIG: {
+  view: string;
+  model: string;
+} = {
+  view: "xdiff:br",
+  model: "xdiffBreak",
 };

--- a/packages/ckeditor5-coremedia-example-data/src/data/DifferencingData.ts
+++ b/packages/ckeditor5-coremedia-example-data/src/data/DifferencingData.ts
@@ -47,12 +47,12 @@ On double click, most browsers select the word as well as the space after.
 Setting such text to bold results in the following difference augmentation:
 </p>
 <p>
-Lorem ${xdiff.change(`ipsum `, {
+Lorem <strong>${xdiff.change(`ipsum `, {
     changes: `<b>Strong</b> style added.`,
   })}\
 ${xdiff.add(` `, {
   endOfDifferences: !hasNext,
-})}\
+})}</strong>\
 dolor\
 </p>`;
 };

--- a/packages/ckeditor5-coremedia-example-data/src/data/DifferencingData.ts
+++ b/packages/ckeditor5-coremedia-example-data/src/data/DifferencingData.ts
@@ -38,9 +38,22 @@ Set to bold with class-attribute change:
 <strong class="some--class">\
 ${xdiff.change(`Lorem ipsum`, {
   changes: `<b>Strong</b> style added with class some--class.`,
-  endOfDifferences: !hasNext,
 })}\
 </strong>.
+</p>
+${sectionHeading("Inline-Style Applied to Text And Following Space")}
+<p>
+On double click, most browsers select the word as well as the space after.
+Setting such text to bold results in the following difference augmentation:
+</p>
+<p>
+Lorem ${xdiff.change(`ipsum `, {
+    changes: `<b>Strong</b> style added.`,
+  })}\
+${xdiff.add(` `, {
+  endOfDifferences: !hasNext,
+})}\
+dolor\
 </p>`;
 };
 

--- a/packages/ckeditor5-coremedia-richtext/src/RichTextDataProcessor.ts
+++ b/packages/ckeditor5-coremedia-richtext/src/RichTextDataProcessor.ts
@@ -51,6 +51,39 @@ class RichTextDataProcessor implements DataProcessor {
 
     this.#richTextSchema = schema;
 
+    /*
+     * We need to mark xdiff:span as elements preserving spaces. Otherwise,
+     * CKEditor would consider adding filler nodes inside xdiff:span elements
+     * only containing spaces. As xdiff:span is only meant to be used in
+     * read-only CKEditor, there is no issue, preventing the filler node
+     * from being inserted.
+     *
+     * Possible alternative: When mapping `xdiff:span` we could replace any
+     * whitespaces with non-breakable-spaces. This solution is cumbersome,
+     * though, so this solution was the easiest one.
+     *
+     * See also: ckeditor/ckeditor5#12324
+     */
+    // @ts-expect-error Typings at DefinitelyTyped only allow this to contain
+    // `pre` element. But for TypeScript migration, CKEditor replaced typing
+    // by `string[]` instead.
+    this.#delegate.domConverter.preElements.push("xdiff:span");
+
+    /*
+     * DevNote: Some idea, if we would want to provide a programmatic
+     * extension point here, i.e., allow plugins to further extend data-processing
+     * rules (like for xdiff:span in Differencing Plugin):
+     *
+     * + These two instances should be instantiated lazily.
+     * + As further late configuration is unlikely, a pattern like "if unset,
+     *   instantiate and remember" should do the trick.
+     * + The method, which then extends the configuration, should just reset
+     *   these variables to `undefined`, so that they will be reevaluated on next
+     *   access.
+     * + Ideally, such an extension point accepts `FilterRuleSetConfiguration`
+     *   as input. This again requires some parsing and some merging algorithm
+     *   with existing parsed and pre-processed rules.
+     */
     this.#toViewFilter = new HtmlFilter(toView, editor);
     this.#toDataProcessor = new ToDataProcessor(new HtmlFilter(toData, editor));
 


### PR DESCRIPTION
## Changes

To fix the issue of false-positive newline highlighting in context of server-side differencing, we have essentially provided one important difference:

We introduced a new artificial `xdiff:br` element, available in data view and especially in editing view. Having this, previous styling has to be adapted for newline highlighting.

* CSS Selector Before: `p > xdiff\:span[xdiff\:class="diff-html-added"]:empty::before`
* CSS Selector Now: `p > xdiff\:br[xdiff\:class="diff-html-added"]::before`

You could still use `:empty` pseudo-class, but it is not required anymore, as `xdiff:br` is always empty.

Further changes, not directly visible, ensure, that differences with whitespace is better handled and whitespace not stripped by CKEditor's processing.

## Further Details

### Issue to Fix

CoreMedia's server side differencing challenges difference highlighting in that way, that, if a word and its following space gets an inline style applied, the space appears once as changed and once as added. The added section only contains the space character.

Example, with some irrelevant attributes stripped and classes simplified:

```xml
<xdiff:span xdiff:class="changed">ipsum </xdiff:span><xdiff:span xdiff:class="added"> </xdiff:span>
```

In its current state, this will result in the same augmented markup in editing view, as if a newline got added directly behind the word:

```xml
<xdiff:span xdiff:class="changed">ipsum&nbsp;</xdiff:span><xdiff:span xdiff:class="added"></xdiff:span>
```

### Analysis

After data-processing the example above, the result is:

```xml
<xdiff:span xdiff:class="changed">ipsum </xdiff:span><xdiff:span xdiff:class="added"> </xdiff:span>
```

When transforming this data view to model, CKEditor decides to make the model element for the _added_ span empty. As such, it cannot be distinguished from the representation of an added newline:

```xml
<xdiff:span xdiff:class="changed">ipsum </xdiff:span><xdiff:span xdiff:class="added"></xdiff:span>
```
