### PR TITLE
fix(playwright): No DOMParser available

### DIFF
--- a/app/src/example-data.js
+++ b/app/src/example-data.js
@@ -9,7 +9,8 @@ import {differencingData} from "@coremedia-internal/ckeditor5-coremedia-example-
 import {grsData} from "@coremedia-internal/ckeditor5-coremedia-example-data/data/GrsData";
 import {loremIpsumData} from "@coremedia-internal/ckeditor5-coremedia-example-data/data/LoremIpsumData";
 import {linkTargetData} from "@coremedia-internal/ckeditor5-coremedia-example-data/data/LinkTargetData";
-import {h1, richtext, richTextDocument} from "@coremedia-internal/ckeditor5-coremedia-example-data/RichText";
+import {h1, richtext} from "@coremedia-internal/ckeditor5-coremedia-example-data/RichText";
+import {richTextDocument} from "@coremedia-internal/ckeditor5-coremedia-example-data/RichTextDOM";
 import {entitiesData} from "@coremedia-internal/ckeditor5-coremedia-example-data/data/EntitiesData";
 
 const CM_RICHTEXT = "http://www.coremedia.com/2003/richtext-1.0";

--- a/packages/ckeditor5-coremedia-example-data/src/RichTextBase.ts
+++ b/packages/ckeditor5-coremedia-example-data/src/RichTextBase.ts
@@ -446,15 +446,3 @@ export const richtext = (
   result += `>${innerXml}</div>`;
   return result;
 };
-
-const domParser = new DOMParser();
-
-export const parseRichTextFromString = (
-  innerXml: Content = "",
-  enforcedNamespaces: ReadonlyArray<string> = []
-): Document => {
-  const xml = richtext(innerXml, true, enforcedNamespaces);
-  return domParser.parseFromString(xml, "text/xml");
-};
-
-export const richTextDocument = parseRichTextFromString("", ["xlink"]);

--- a/packages/ckeditor5-coremedia-example-data/src/RichTextDOM.ts
+++ b/packages/ckeditor5-coremedia-example-data/src/RichTextDOM.ts
@@ -1,0 +1,13 @@
+import { Content, richtext } from "./RichTextBase";
+
+const domParser = new DOMParser();
+
+export const parseRichTextFromString = (
+  innerXml: Content = "",
+  enforcedNamespaces: ReadonlyArray<string> = []
+): Document => {
+  const xml = richtext(innerXml, true, enforcedNamespaces);
+  return domParser.parseFromString(xml, "text/xml");
+};
+
+export const richTextDocument = parseRichTextFromString("", ["xlink"]);

--- a/packages/ckeditor5-coremedia-example-data/src/data/LinkTargetData.ts
+++ b/packages/ckeditor5-coremedia-example-data/src/data/LinkTargetData.ts
@@ -1,5 +1,6 @@
 import { lorem } from "../LoremIpsum";
-import { em, h1, richtext, richTextDocument } from "../RichText";
+import { em, h1, richtext } from "../RichText";
+import { richTextDocument } from "../RichTextDOM";
 import { ExampleData } from "../ExampleData";
 
 const SOME_TARGET = "somewhere";


### PR DESCRIPTION
For Playwright tests, we don't have jsdom at hand, and thus, we cannot create a DOMParser instance.

Moved corresponding code to extra file `RichTextDOM` which can now be used by tests or for example-data creation where JSDOM is available.