### PR TITLE
Fixes ESLint Warnings and Raises them to Errors

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -57,6 +57,7 @@
 
     "@typescript-eslint/consistent-type-definitions": ["error", "interface"],
     "@typescript-eslint/consistent-type-assertions": ["error", { "assertionStyle": "as" }],
+    "@typescript-eslint/no-non-null-assertion": "error",
 
     "max-statements-per-line": ["error", { "max": 1 }],
 

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -72,6 +72,9 @@
     "no-unused-expressions": "off",
     "@typescript-eslint/no-unused-expressions": ["error", { "allowTernary": true, "allowShortCircuit": true }],
 
+    "no-unused-vars": "off",
+    "@typescript-eslint/no-unused-vars": "error",
+
     "@typescript-eslint/prefer-for-of": "error",
     "@typescript-eslint/prefer-function-type": "error",
     "@typescript-eslint/prefer-namespace-keyword": "error",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -97,6 +97,8 @@
     "@typescript-eslint/type-annotation-spacing": "error",
     "@typescript-eslint/unified-signatures": "error",
 
+    "@typescript-eslint/prefer-ts-expect-error": "error",
+
     // eslint-plugin-import
     "import/no-extraneous-dependencies": ["error", { "optionalDependencies": false }],
 

--- a/packages/ckeditor5-coremedia-link/__tests__/linktarget/config/DefaultTarget.test.ts
+++ b/packages/ckeditor5-coremedia-link/__tests__/linktarget/config/DefaultTarget.test.ts
@@ -23,7 +23,7 @@ describe("DefaultTarget", () => {
       const options = DEFAULT_TARGETS_ARRAY.find((definition) => name === definition.name);
       // Precondition-check
       expect(options).toBeDefined();
-      const { title: actualTitle } = options!;
+      const { title: actualTitle } = options ?? { title: "unexpected undefined state" };
       expect(actualTitle).toStrictEqual(expectedTitle);
     });
 
@@ -37,7 +37,8 @@ describe("DefaultTarget", () => {
       const options = DEFAULT_TARGETS_ARRAY.find((definition) => name === definition.name);
       // Precondition-check
       expect(options).toBeDefined();
-      const { icon: actualIcon } = options!;
+      // default: provoke failure, unexpected as previous check guaranteed options to be defined.
+      const { icon: actualIcon } = options ?? { icon: false };
       expect(actualIcon).toBeTruthy();
     });
   });
@@ -77,7 +78,7 @@ describe("DefaultTarget", () => {
       const options = getDefaultTargetDefinition(name);
       // Precondition-check
       expect(options).toBeDefined();
-      const { title: actualTitle } = options!;
+      const { title: actualTitle } = options ?? { title: "unexpected undefined state" };
       expect(actualTitle).toStrictEqual(expectedTitle);
     });
   });

--- a/packages/ckeditor5-coremedia-richtext/__tests__/ToDataProcessor.test.ts
+++ b/packages/ckeditor5-coremedia-richtext/__tests__/ToDataProcessor.test.ts
@@ -101,10 +101,6 @@ type NamedTestData = [
 ];
 
 /**
- * Processing Instructions.
- */
-const pi = `<?xml version="1.0" encoding="utf-8"?>`;
-/**
  * Some text fixture for testing.
  */
 const fxLtrText = "Lorem ipsum dolor.";

--- a/packages/ckeditor5-dataprocessor-support/__tests__/ElementProxy.test.ts
+++ b/packages/ckeditor5-dataprocessor-support/__tests__/ElementProxy.test.ts
@@ -752,7 +752,7 @@ describe("ElementProxy.applyRules()", () => {
                 if (!!descriptor) {
                   // False positive? Checks assume, that descriptor may be undefined here. But how?
                   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                  // @ts-ignore
+                  // @ts-expect-error Possibly false positive.
                   descriptor.set("prefixed:" + descriptor.get());
                 }
               }


### PR DESCRIPTION
Fixes ESLint Warnings:

* `@typescript-eslint/no-unused-vars`
* `@typescript-eslint/no-non-null-assertion`

Raising them to error level, so that we don't miss them.

Also added:

* `@typescript-eslint/prefer-ts-expect-error`

and fixed the only issue. We prefer `ts-expect-error` so that we are aware, when the corresponding type got fixed.