### PR TITLE
CKEditor 5 Update in peer dependencies

### DIFF
--- a/packages/ckeditor5-core-common/package.json
+++ b/packages/ckeditor5-core-common/package.json
@@ -27,7 +27,7 @@
     "typescript": "^4.8.2"
   },
   "peerDependencies": {
-    "@ckeditor/ckeditor5-core": "^34.2.0"
+    "@ckeditor/ckeditor5-core": "^35.1.0"
   },
   "dependencies": {
     "@coremedia/ckeditor5-common": "^9.0.0",

--- a/packages/ckeditor5-coremedia-content-clipboard/package.json
+++ b/packages/ckeditor5-coremedia-content-clipboard/package.json
@@ -41,12 +41,12 @@
     "./*": "./dist/*.js"
   },
   "peerDependencies": {
-    "@ckeditor/ckeditor5-clipboard": "^34.2.0",
-    "@ckeditor/ckeditor5-core": "^34.2.0",
-    "@ckeditor/ckeditor5-engine": "^34.2.0",
-    "@ckeditor/ckeditor5-html-support": "^34.2.0",
-    "@ckeditor/ckeditor5-undo": "^34.2.0",
-    "@ckeditor/ckeditor5-utils": "^34.2.0",
+    "@ckeditor/ckeditor5-clipboard": "^35.1.0",
+    "@ckeditor/ckeditor5-core": "^35.1.0",
+    "@ckeditor/ckeditor5-engine": "^35.1.0",
+    "@ckeditor/ckeditor5-html-support": "^35.1.0",
+    "@ckeditor/ckeditor5-undo": "^35.1.0",
+    "@ckeditor/ckeditor5-utils": "^35.1.0",
     "@coremedia/service-agent": "^1.1.0"
   },
   "dependencies": {

--- a/packages/ckeditor5-coremedia-differencing/package.json
+++ b/packages/ckeditor5-coremedia-differencing/package.json
@@ -32,9 +32,9 @@
     "typescript": "^4.8.2"
   },
   "peerDependencies": {
-    "@ckeditor/ckeditor5-core": "^34.2.0",
-    "@ckeditor/ckeditor5-engine": "^34.2.0",
-    "@ckeditor/ckeditor5-utils": "^34.2.0"
+    "@ckeditor/ckeditor5-core": "^35.1.0",
+    "@ckeditor/ckeditor5-engine": "^35.1.0",
+    "@ckeditor/ckeditor5-utils": "^35.1.0"
   },
   "dependencies": {
     "@coremedia/ckeditor5-common": "^9.0.0",

--- a/packages/ckeditor5-coremedia-images/package.json
+++ b/packages/ckeditor5-coremedia-images/package.json
@@ -37,10 +37,10 @@
     "typescript": "^4.8.2"
   },
   "peerDependencies": {
-    "@ckeditor/ckeditor5-core": "^34.2.0",
-    "@ckeditor/ckeditor5-engine": "^34.2.0",
-    "@ckeditor/ckeditor5-image": "^34.2.0",
-    "@ckeditor/ckeditor5-utils": "^34.2.0",
+    "@ckeditor/ckeditor5-core": "^35.1.0",
+    "@ckeditor/ckeditor5-engine": "^35.1.0",
+    "@ckeditor/ckeditor5-image": "^35.1.0",
+    "@ckeditor/ckeditor5-utils": "^35.1.0",
     "@coremedia/service-agent": "^1.1.0"
   },
   "dependencies": {

--- a/packages/ckeditor5-coremedia-link/package.json
+++ b/packages/ckeditor5-coremedia-link/package.json
@@ -43,13 +43,13 @@
     "typescript": "^4.8.2"
   },
   "peerDependencies": {
-    "@ckeditor/ckeditor5-clipboard": "^34.2.0",
-    "@ckeditor/ckeditor5-core": "^34.2.0",
-    "@ckeditor/ckeditor5-engine": "^34.2.0",
-    "@ckeditor/ckeditor5-link": "^34.2.0",
-    "@ckeditor/ckeditor5-typing": "^34.2.0",
-    "@ckeditor/ckeditor5-ui": "^34.2.0",
-    "@ckeditor/ckeditor5-utils": "^34.2.0",
+    "@ckeditor/ckeditor5-clipboard": "^35.1.0",
+    "@ckeditor/ckeditor5-core": "^35.1.0",
+    "@ckeditor/ckeditor5-engine": "^35.1.0",
+    "@ckeditor/ckeditor5-link": "^35.1.0",
+    "@ckeditor/ckeditor5-typing": "^35.1.0",
+    "@ckeditor/ckeditor5-ui": "^35.1.0",
+    "@ckeditor/ckeditor5-utils": "^35.1.0",
     "@coremedia/service-agent": "^1.1.0"
   },
   "dependencies": {

--- a/packages/ckeditor5-coremedia-richtext-support/package.json
+++ b/packages/ckeditor5-coremedia-richtext-support/package.json
@@ -36,10 +36,10 @@
     "./*": "./dist/*.js"
   },
   "peerDependencies": {
-    "@ckeditor/ckeditor5-core": "^34.2.0",
-    "@ckeditor/ckeditor5-engine": "^34.2.0",
-    "@ckeditor/ckeditor5-html-support": "^34.2.0",
-    "@ckeditor/ckeditor5-utils": "^34.2.0"
+    "@ckeditor/ckeditor5-core": "^35.1.0",
+    "@ckeditor/ckeditor5-engine": "^35.1.0",
+    "@ckeditor/ckeditor5-html-support": "^35.1.0",
+    "@ckeditor/ckeditor5-utils": "^35.1.0"
   },
   "dependencies": {
     "@coremedia/ckeditor5-logging": "^9.0.0"

--- a/packages/ckeditor5-coremedia-richtext/package.json
+++ b/packages/ckeditor5-coremedia-richtext/package.json
@@ -34,9 +34,9 @@
     "./*": "./dist/*.js"
   },
   "peerDependencies": {
-    "@ckeditor/ckeditor5-core": "^34.2.0",
-    "@ckeditor/ckeditor5-engine": "^34.2.0",
-    "@ckeditor/ckeditor5-utils": "^34.2.0"
+    "@ckeditor/ckeditor5-core": "^35.1.0",
+    "@ckeditor/ckeditor5-engine": "^35.1.0",
+    "@ckeditor/ckeditor5-utils": "^35.1.0"
   },
   "dependencies": {
     "@coremedia/ckeditor5-dataprocessor-support": "^9.0.0",

--- a/packages/ckeditor5-coremedia-studio-essentials/package.json
+++ b/packages/ckeditor5-coremedia-studio-essentials/package.json
@@ -40,11 +40,11 @@
     "typescript": "^4.8.2"
   },
   "peerDependencies": {
-    "@ckeditor/ckeditor5-core": "^34.2.0",
-    "@ckeditor/ckeditor5-engine": "^34.2.0",
-    "@ckeditor/ckeditor5-typing": "^34.2.0",
-    "@ckeditor/ckeditor5-ui": "^34.2.0",
-    "@ckeditor/ckeditor5-utils": "^34.2.0"
+    "@ckeditor/ckeditor5-core": "^35.1.0",
+    "@ckeditor/ckeditor5-engine": "^35.1.0",
+    "@ckeditor/ckeditor5-typing": "^35.1.0",
+    "@ckeditor/ckeditor5-ui": "^35.1.0",
+    "@ckeditor/ckeditor5-utils": "^35.1.0"
   },
   "dependencies": {
     "@coremedia/ckeditor5-coremedia-richtext": "^9.0.0",

--- a/packages/ckeditor5-coremedia-studio-integration-mock/package.json
+++ b/packages/ckeditor5-coremedia-studio-integration-mock/package.json
@@ -35,7 +35,7 @@
     "typescript": "^4.8.2"
   },
   "peerDependencies": {
-    "@ckeditor/ckeditor5-core": "^34.2.0",
+    "@ckeditor/ckeditor5-core": "^35.1.0",
     "@coremedia/service-agent": "^1.1.0"
   },
   "dependencies": {

--- a/packages/ckeditor5-dataprocessor-support/package.json
+++ b/packages/ckeditor5-dataprocessor-support/package.json
@@ -34,8 +34,8 @@
     "typescript": "^4.8.2"
   },
   "peerDependencies": {
-    "@ckeditor/ckeditor5-core": "^34.2.0",
-    "@ckeditor/ckeditor5-engine": "^34.2.0"
+    "@ckeditor/ckeditor5-core": "^35.1.0",
+    "@ckeditor/ckeditor5-engine": "^35.1.0"
   },
   "dependencies": {
     "@coremedia/ckeditor5-common": "^9.0.0",

--- a/packages/ckeditor5-font-mapper/package.json
+++ b/packages/ckeditor5-font-mapper/package.json
@@ -28,10 +28,10 @@
     "typescript": "^4.8.2"
   },
   "peerDependencies": {
-    "@ckeditor/ckeditor5-clipboard": "^34.2.0",
-    "@ckeditor/ckeditor5-core": "^34.2.0",
-    "@ckeditor/ckeditor5-engine": "^34.2.0",
-    "@ckeditor/ckeditor5-utils": "^34.2.0"
+    "@ckeditor/ckeditor5-clipboard": "^35.1.0",
+    "@ckeditor/ckeditor5-core": "^35.1.0",
+    "@ckeditor/ckeditor5-engine": "^35.1.0",
+    "@ckeditor/ckeditor5-utils": "^35.1.0"
   },
   "dependencies": {
     "@coremedia/ckeditor5-core-common": "^9.0.0",


### PR DESCRIPTION
This is a follow up of https://github.com/CoreMedia/ckeditor-plugins/pull/94. 
Unfortunately, update-latest didn't update the versions in peer dependencies.