### PR TITLE
Fixes #101: Address Ambiguous Class Mappings By Warnings and Documentation

### DIFF
--- a/packages/ckeditor5-coremedia-richtext/__tests__/rules/Heading.test.ts
+++ b/packages/ckeditor5-coremedia-richtext/__tests__/rules/Heading.test.ts
@@ -71,6 +71,7 @@ describe("CoreMediaRichTextConfig: Headings", () => {
 
   const data: DataProcessingTestCase[] = [
     {
+      // See also #101 regarding ambiguous data states.
       name: "HEADING#1: Should prefer higher heading class (here: 1 and 2 → prefer 1).",
       direction: Direction.toDataView,
       data: wrapContent(`<p class="p--heading-1 p--heading-2">${text}</p>`),

--- a/packages/ckeditor5-coremedia-richtext/__tests__/rules/Inline.test.ts
+++ b/packages/ckeditor5-coremedia-richtext/__tests__/rules/Inline.test.ts
@@ -226,10 +226,26 @@ describe("CoreMediaRichTextConfig: Miscellaneous Inline Tags", () => {
     })
   );
 
+  const regressionFixtures: DataProcessingTestCase[] = [
+    {
+      name: `regression#1: Should map span with "strike underline" to <s> and <u> element.`,
+      data: wrapContent(`<p><span class="underline strike">${text}</span></p>`),
+      // <s><u> would also be valid.
+      dataView: wrapContent(`<p><u><s>${text}</s></u></p>`),
+    },
+    {
+      name: `regression#1: Should map span with "strike underline" to <s> and <u> element.`,
+      data: wrapContent(`<p><span class="strike underline">${text}</span></p>`),
+      // <u><s> would also be valid.
+      dataView: wrapContent(`<p><s><u>${text}</u></s></p>`),
+    },
+  ];
+
   const data: DataProcessingTestCase[] = [
     ...replaceInlineSimpleFixtures,
     ...replaceInlineBySpanFixtures,
     ...asIsFixtures,
+    ...regressionFixtures,
   ];
 
   allDataProcessingTests(data);

--- a/packages/ckeditor5-dataprocessor-support/src/RulesLogger.ts
+++ b/packages/ckeditor5-dataprocessor-support/src/RulesLogger.ts
@@ -1,0 +1,49 @@
+import Logger from "@coremedia/ckeditor5-logging/logging/Logger";
+import LoggerProvider from "@coremedia/ckeditor5-logging/logging/LoggerProvider";
+
+/**
+ * Prefix for issues triggered by Data Processor.
+ */
+export const DATA_PROCESSOR_ISSUE_PREFIX = "DP";
+
+/**
+ * Used for general issues in data-processing.
+ */
+export const DP_GENERAL = `${DATA_PROCESSOR_ISSUE_PREFIX}#0001`;
+
+/**
+ * Used for detected ambiguous states regarding element mapping.
+ */
+export const DP_AMBIGUOUS_ELEMENT_STATE = `${DATA_PROCESSOR_ISSUE_PREFIX}#0002`;
+
+/**
+ * Used for detected ambiguous states regarding attribute mapping.
+ */
+export const DP_AMBIGUOUS_ATTRIBUTE_STATE = `${DATA_PROCESSOR_ISSUE_PREFIX}#0003`;
+
+const RULES_LOGGER_NAME = "Rules";
+
+/**
+ * Logger for rules.
+ */
+export const rulesLogger: Logger = LoggerProvider.getLogger(RULES_LOGGER_NAME);
+
+/**
+ * Triggers a warning on an ambiguous element state.
+ *
+ * @param msg - details on ambiguous state
+ * @param data - more data to apply
+ */
+export const warnOnAmbiguousElementState = (msg: string, ...data: unknown[]) => {
+  rulesLogger.warn(`${DP_AMBIGUOUS_ELEMENT_STATE} - Ambiguous Element State: ${msg}`, ...data);
+};
+
+/**
+ * Triggers a warning on an ambiguous attribute state.
+ *
+ * @param msg - details on ambiguous state
+ * @param data - more data to apply
+ */
+export const warnOnAmbiguousAttributeState = (msg: string, ...data: unknown[]) => {
+  rulesLogger.warn(`${DP_AMBIGUOUS_ATTRIBUTE_STATE} - Ambiguous Attribute State: ${msg}`, ...data);
+};

--- a/packages/ckeditor5-dataprocessor-support/src/index-doc.ts
+++ b/packages/ckeditor5-dataprocessor-support/src/index-doc.ts
@@ -17,5 +17,7 @@ export { default as NodeProxy } from "./NodeProxy";
 
 export * from "./Rules";
 
+export * as RulesLogger from "./RulesLogger";
+
 export * from "./TextProxy";
 export { default as TextProxy } from "./TextProxy";


### PR DESCRIPTION
This PR documents ambiguous class mapping behavior, provides corresponding tests and raises warnings if ambiguous states in data are detected.

## Details

As described in #101 class mappings may be ambiguous:

```html
<span class="underline strike">Lorem</span>
```

This ambiguity is triggered by so-called _reserved classes_, i.e., class attribute values in CoreMedia RichText 1.0, which denote a `<span>` to be mapped to a different representation in data view (such as `<u>` or `<s>` in the example above).

While we could decide to map such a state to:

```html
<u><s>Lorem</s></u>
```

such a decision would raise additional issues like:

* The data-processed example later retrieved by `getData()` would differ:

  ```html
  <span class="underline"><span class="strike">Lorem</span></span>
  ```

* Where to apply additional attributes, additional classes to, like for:

  ```html
  <span class="underline strike custom" dir="rtl" lang="en">Lorem</span>
  ```

**TL;DR:** Any handling of such an ambiguous state in data provides short-comings and possible bad guesses.

Because of this, and because we already have similar ambiguity resolution at other places like for:

```html
<p class="p--heading-1 p--heading-2 align--right align--left"
   xml:lang="en" lang="de">
  Lorem
</p>
```

which may resolve to anything eventually. Thus, the following may be a valid value in return for `editor.getData()`:

```html
<p class="p--heading-1 align--right"
   lang="de">
  Lorem
</p>
```

## See Also

* #101
