### PR TITLE
Studio Essentials: Adapt package name to directory name to fit naming policy.

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ pnpm install @coremedia/ckeditor5-coremedia-studio-essentials
 ```
 
 ```javascript
-import CoreMediaStudioEssentials from "@coremedia/ckeditor5-studio-essentials/CoreMediaStudioEssentials";
+import CoreMediaStudioEssentials from "@coremedia/ckeditor5-coremedia-studio-essentials/CoreMediaStudioEssentials";
 
 ClassicEditor.create(document.querySelector('#editor'), {
   plugins: [
@@ -140,8 +140,11 @@ previously `setData()` call. A typical approach is:
 [`ckeditor5-coremedia-images`]: <./packages/ckeditor5-coremedia-images> "@coremedia/ckeditor5-coremedia-images"
 [`ckeditor5-coremedia-link`]: <./packages/ckeditor5-coremedia-link> "@coremedia/ckeditor5-coremedia-link"
 [`ckeditor5-coremedia-richtext`]: <./packages/ckeditor5-coremedia-richtext> "@coremedia/ckeditor5-coremedia-richtext"
+
 [`ckeditor5-coremedia-richtext-support`]: <./packages/ckeditor5-coremedia-richtext-support> "@coremedia/ckeditor5-coremedia-richtext-support"
-[`ckeditor5-coremedia-studio-essentials`]: <./packages/ckeditor5-coremedia-studio-essentials> "@coremedia/ckeditor5-studio-essentials"
+
+[`ckeditor5-coremedia-studio-essentials`]: <./packages/ckeditor5-coremedia-studio-essentials> "@coremedia/ckeditor5-coremedia-studio-essentials"
+
 [`ckeditor5-coremedia-studio-integration`]: <./packages/ckeditor5-coremedia-studio-integration> "@coremedia/ckeditor5-coremedia-studio-integration"
 [`ckeditor5-coremedia-studio-integration-mock`]: <./packages/ckeditor5-coremedia-studio-integration-mock> "@coremedia/ckeditor5-coremedia-studio-integration-mock"
 [`ckeditor5-dataprocessor-support`]: <./packages/ckeditor5-dataprocessor-support> "@coremedia/ckeditor5-dataprocessor-support"

--- a/app/package.json
+++ b/app/package.json
@@ -39,10 +39,10 @@
     "@coremedia/ckeditor5-coremedia-images": "9.1.1-rc.0",
     "@coremedia/ckeditor5-coremedia-link": "9.1.1-rc.0",
     "@coremedia/ckeditor5-coremedia-richtext": "9.1.1-rc.0",
+    "@coremedia/ckeditor5-coremedia-studio-essentials": "9.1.1-rc.0",
     "@coremedia/ckeditor5-coremedia-studio-integration-mock": "9.1.1-rc.0",
     "@coremedia/ckeditor5-dataprocessor-support": "9.1.1-rc.0",
     "@coremedia/ckeditor5-font-mapper": "9.1.1-rc.0",
-    "@coremedia/ckeditor5-studio-essentials": "9.1.1-rc.0",
     "@coremedia/service-agent": "^1.1.2",
     "xml-formatter": "^2.6.1"
   },

--- a/app/src/ckeditor.js
+++ b/app/src/ckeditor.js
@@ -45,7 +45,7 @@ import CoreMediaStudioEssentials, {
   COREMEDIA_RICHTEXT_CONFIG_KEY,
   COREMEDIA_RICHTEXT_SUPPORT_CONFIG_KEY,
   Strictness,
-} from "@coremedia/ckeditor5-studio-essentials/CoreMediaStudioEssentials";
+} from "@coremedia/ckeditor5-coremedia-studio-essentials/CoreMediaStudioEssentials";
 import { initDragExamples } from "./dragExamples";
 import { replaceByElementAndClassBackAndForth } from "@coremedia/ckeditor5-coremedia-richtext/rules/ReplaceBy";
 import { COREMEDIA_MOCK_CONTENT_PLUGIN } from "@coremedia/ckeditor5-coremedia-studio-integration-mock/content/MockContentPlugin";

--- a/packages/ckeditor5-coremedia-studio-essentials/package.json
+++ b/packages/ckeditor5-coremedia-studio-essentials/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@coremedia/ckeditor5-studio-essentials",
+  "name": "@coremedia/ckeditor5-coremedia-studio-essentials",
   "version": "9.1.1-rc.0",
   "description": "CoreMedia Studio: Aggregator Plugin for essential plugins",
   "keywords": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,10 +77,10 @@ importers:
       '@coremedia/ckeditor5-coremedia-images': 9.1.1-rc.0
       '@coremedia/ckeditor5-coremedia-link': 9.1.1-rc.0
       '@coremedia/ckeditor5-coremedia-richtext': 9.1.1-rc.0
+      '@coremedia/ckeditor5-coremedia-studio-essentials': 9.1.1-rc.0
       '@coremedia/ckeditor5-coremedia-studio-integration-mock': 9.1.1-rc.0
       '@coremedia/ckeditor5-dataprocessor-support': 9.1.1-rc.0
       '@coremedia/ckeditor5-font-mapper': 9.1.1-rc.0
-      '@coremedia/ckeditor5-studio-essentials': 9.1.1-rc.0
       '@coremedia/service-agent': ^1.1.2
       circular-dependency-plugin: ^5.2.2
       css-loader: ^6.7.1
@@ -128,10 +128,10 @@ importers:
       '@coremedia/ckeditor5-coremedia-images': link:../packages/ckeditor5-coremedia-images
       '@coremedia/ckeditor5-coremedia-link': link:../packages/ckeditor5-coremedia-link
       '@coremedia/ckeditor5-coremedia-richtext': link:../packages/ckeditor5-coremedia-richtext
+      '@coremedia/ckeditor5-coremedia-studio-essentials': link:../packages/ckeditor5-coremedia-studio-essentials
       '@coremedia/ckeditor5-coremedia-studio-integration-mock': link:../packages/ckeditor5-coremedia-studio-integration-mock
       '@coremedia/ckeditor5-dataprocessor-support': link:../packages/ckeditor5-dataprocessor-support
       '@coremedia/ckeditor5-font-mapper': link:../packages/ckeditor5-font-mapper
-      '@coremedia/ckeditor5-studio-essentials': link:../packages/ckeditor5-coremedia-studio-essentials
       '@coremedia/service-agent': 1.1.2
       xml-formatter: 2.6.1
     devDependencies:


### PR DESCRIPTION
The package `@coremedia/ckeditor5-studio-essentials` has been renamed to `@coremedia/ckeditor-coremedia-studio-essentials`.

This is a breaking change and requires some action when upgrading to upcoming major version:
- Dependencies to this package have to be changed to the new name.
- All imports in *.ts files have to been changed to the new name.