### PR TITLE
Tests for lists

### DIFF
--- a/itest/src/DocumentLists.test.ts
+++ b/itest/src/DocumentLists.test.ts
@@ -21,14 +21,15 @@ import {
 import "./expect/Expectations";
 import { blobReference } from "@coremedia-internal/ckeditor5-coremedia-example-data/Images";
 
+const olString = "ol";
+const ulString = "ul";
+
 /**
  * This test is a test for the CKEditor 5 Document List feature and reflects the current state.
  * It does not always fit our expectations, but it is currently implemented in CKEditor 5 like that.
  *
  * On an update of CKEditor 5 those tests might signalize changes in CKEditor 5 behavior.
  */
-const olString = "ol";
-const ulString = "ul";
 describe("Document List Feature", () => {
   // noinspection DuplicatedCode
   let application: ApplicationWrapper;

--- a/itest/src/DocumentLists.test.ts
+++ b/itest/src/DocumentLists.test.ts
@@ -8,6 +8,8 @@ import "./expect/Expectations";
  *
  * On an update of CKEditor 5 those tests might signalize changes in CKEditor 5 behavior.
  */
+const olString = "ol";
+const ulString = "ul";
 describe("Document List Feature", () => {
   // noinspection DuplicatedCode
   let application: ApplicationWrapper;
@@ -32,16 +34,12 @@ describe("Document List Feature", () => {
     application.console.close();
   });
 
-  describe("List attributes", () => {
-    //Unfortunately we have to import all parameters with ${} and the element name
-    //is equal to the function name. Therefore, store the element name first as a string.
-    const olString = "ol";
-    const ulString = "ul";
-    it.each`
-      listElement | listElementFunction
-      ${olString} | ${ol}
-      ${ulString} | ${ul}
-    `("$listElement contains attributes", async ({ listElement, listElementFunction }) => {
+  describe.each`
+    listElement | listElementFunction
+    ${olString} | ${ol}
+    ${ulString} | ${ul}
+  `(`$listElement: List attributes`, ({ listElement, listElementFunction }) => {
+    it(`${listElement} contains attributes`, async () => {
       const { editor } = application;
       const { ui } = editor;
       const editableHandle = await ui.getEditableElement();
@@ -70,11 +68,7 @@ describe("Document List Feature", () => {
       await expect(listElementEditable).toMatchAttribute("lang", "de");
     });
 
-    it.each`
-      listElement | listElementFunction
-      ${olString} | ${ol}
-      ${ulString} | ${ul}
-    `("$listElement, li element contains attributes", async ({ listElement, listElementFunction }) => {
+    it(`${listElement}, li element contains attributes`, async () => {
       const { editor } = application;
       const { ui } = editor;
       const editableHandle = await ui.getEditableElement();
@@ -99,11 +93,7 @@ describe("Document List Feature", () => {
       await expect(listItemElement).toMatchAttribute("lang", "de");
     });
 
-    it.each`
-      listElement | listElementFunction
-      ${olString} | ${ol}
-      ${ulString} | ${ul}
-    `("$listElement and li element contain attributes", async ({ listElement, listElementFunction }) => {
+    it(`${listElement} and li element contain attributes`, async () => {
       const { editor } = application;
       const { ui } = editor;
       const editableHandle = await ui.getEditableElement();

--- a/itest/src/DocumentLists.test.ts
+++ b/itest/src/DocumentLists.test.ts
@@ -143,7 +143,7 @@ describe("Document List Feature", () => {
     listElement | listElementFunction
     ${olString} | ${ol}
     ${ulString} | ${ul}
-  `("Nested Elements in list item (li) according to dtd", ({ listElement, listElementFunction }) => {
+  `(`$listElement: Nested Elements in list item (li) according to dtd`, ({ listElement, listElementFunction }) => {
     //According to dtd p is allowed, but it will be removed by ckeditor
     it("p is removed if it is nested in li", async () => {
       const { editor } = application;
@@ -158,6 +158,30 @@ describe("Document List Feature", () => {
       const listItemElement = (await listElementEditable)?.$("li");
       const pTag = (await listItemElement)?.$("p");
       await expect(await pTag).toBeNull();
+    });
+    it.each`
+      nestedListElement | nestedListElementFunction
+      ${olString}       | ${ol}
+      ${ulString}       | ${ul}
+    `("$nestedListElement is accepted as nested element", async ({ nestedListElement, nestedListElementFunction }) => {
+      const { editor } = application;
+      const { ui } = editor;
+      const editableHandle = await ui.getEditableElement();
+
+      const text = `Lorem Ipsum`;
+      const data = richtext(listElementFunction(li(nestedListElementFunction(li(text)))));
+      await editor.setDataAndGetDataView(data);
+
+      const listElementEditable = editableHandle.$(`${listElement}`);
+      const listItemElement = (await listElementEditable)?.$("li");
+      await expect(await listItemElement).not.toBeNull();
+
+      const nestedListElementEditable = (await listItemElement)?.$(nestedListElement);
+      await expect(await nestedListElementEditable).not.toBeNull();
+
+      const nestedListItem = (await nestedListElementEditable)?.$("li");
+      await expect(await nestedListItem).not.toBeNull();
+      await expect(await nestedListItem).toHaveText(text);
     });
   });
 });

--- a/itest/src/DocumentLists.test.ts
+++ b/itest/src/DocumentLists.test.ts
@@ -38,7 +38,7 @@ describe("Document List Feature", () => {
       listElement | listElementFunction
       ${olString} | ${ol}
       ${ulString} | ${ul}
-    `("$listElement Attributes", async ({ listElement, listElementFunction }) => {
+    `("$listElement contains attributes", async ({ listElement, listElementFunction }) => {
       const { editor } = application;
       const { ui } = editor;
       const editableHandle = await ui.getEditableElement();
@@ -65,6 +65,35 @@ describe("Document List Feature", () => {
       await expect(listElementEditable).toMatchAttribute("class", "anyclass");
       await expect(listElementEditable).toMatchAttribute("dir", "ltr");
       await expect(listElementEditable).toMatchAttribute("lang", "de");
+    });
+
+    it.each`
+      listElement | listElementFunction
+      ${olString} | ${ol}
+      ${ulString} | ${ul}
+    `("$listElement, li element contains attributes", async ({ listElement, listElementFunction }) => {
+      const { editor } = application;
+      const { ui } = editor;
+      const editableHandle = await ui.getEditableElement();
+
+      const text = `Lorem Ipsum`;
+      const data = richtext(
+        listElementFunction(
+          li(text, {
+            "class": "anyclass",
+            "dir": "ltr",
+            "xml:lang": "de",
+            "lang": "de",
+          })
+        )
+      );
+      await editor.setDataAndGetDataView(data);
+      const listElementEditable = editableHandle.$(`${listElement}`);
+      const listItemElement = (await listElementEditable)?.$("li");
+      expect(listItemElement).not.toBeNull();
+      await expect(listItemElement).toMatchAttribute("class", "anyclass");
+      await expect(listItemElement).toMatchAttribute("dir", "ltr");
+      await expect(listItemElement).toMatchAttribute("lang", "de");
     });
   });
 });

--- a/itest/src/DocumentLists.test.ts
+++ b/itest/src/DocumentLists.test.ts
@@ -245,22 +245,15 @@ describe("Document List Feature", () => {
       await expect(await nestedListItem).toHaveText(text);
     });
 
-    const preString = "pre";
-    const blockquoteString = "blockquote";
-    const spanString = "span";
-    const strongString = "strong";
-    const subString = "sub";
-    const supString = "sup";
-
     it.each`
-      nestedElement       | nestedElementFunction
-      ${preString}        | ${pre}
-      ${blockquoteString} | ${blockquote}
-      ${spanString}       | ${span}
-      ${strongString}     | ${strong}
-      ${subString}        | ${sub}
-      ${supString}        | ${sup}
-      ${"i"}              | ${em}
+      nestedElement   | nestedElementFunction
+      ${"pre"}        | ${pre}
+      ${"blockquote"} | ${blockquote}
+      ${"span"}       | ${span}
+      ${"strong"}     | ${strong}
+      ${"sub"}        | ${sub}
+      ${"sup"}        | ${sup}
+      ${"i"}          | ${em}
     `("nested $nestedElement", async ({ nestedElement, nestedElementFunction }) => {
       const { editor } = application;
       const { ui } = editor;

--- a/itest/src/DocumentLists.test.ts
+++ b/itest/src/DocumentLists.test.ts
@@ -3,7 +3,10 @@ import { li, ol, richtext, ul } from "@coremedia-internal/ckeditor5-coremedia-ex
 import "./expect/Expectations";
 
 /**
+ * This test is a test for the CKEditor 5 Document List feature and reflects the current state.
+ * It does not always fit our expectations, but it is currently implemented in CKEditor 5 like that.
  *
+ * On an update of CKEditor 5 those tests might signalize changes in CKEditor 5 behavior.
  */
 describe("Document List Feature", () => {
   // noinspection DuplicatedCode
@@ -92,6 +95,46 @@ describe("Document List Feature", () => {
       const listItemElement = (await listElementEditable)?.$("li");
       expect(listItemElement).not.toBeNull();
       await expect(listItemElement).toMatchAttribute("class", "anyclass");
+      await expect(listItemElement).toMatchAttribute("dir", "ltr");
+      await expect(listItemElement).toMatchAttribute("lang", "de");
+    });
+
+    it.each`
+      listElement | listElementFunction
+      ${olString} | ${ol}
+      ${ulString} | ${ul}
+    `("$listElement and li element contain attributes", async ({ listElement, listElementFunction }) => {
+      const { editor } = application;
+      const { ui } = editor;
+      const editableHandle = await ui.getEditableElement();
+
+      const text = `Lorem Ipsum`;
+      const data = richtext(
+        listElementFunction(
+          li(text, {
+            "class": "liclass",
+            "dir": "ltr",
+            "xml:lang": "de",
+            "lang": "de",
+          }),
+          {
+            "class": `${listElement}Class`,
+            "dir": "rtl",
+            "xml:lang": "en",
+            "lang": "en",
+          }
+        )
+      );
+      await editor.setDataAndGetDataView(data);
+      const listElementEditable = editableHandle.$(`${listElement}`);
+      expect(listElementEditable).not.toBeNull();
+      await expect(listElementEditable).toMatchAttribute("class", `${listElement}Class`);
+      await expect(listElementEditable).toMatchAttribute("dir", "rtl");
+      await expect(listElementEditable).toMatchAttribute("lang", "en");
+
+      const listItemElement = (await listElementEditable)?.$("li");
+      expect(listItemElement).not.toBeNull();
+      await expect(listItemElement).toMatchAttribute("class", "liclass");
       await expect(listItemElement).toMatchAttribute("dir", "ltr");
       await expect(listItemElement).toMatchAttribute("lang", "de");
     });

--- a/itest/src/DocumentLists.test.ts
+++ b/itest/src/DocumentLists.test.ts
@@ -1,0 +1,70 @@
+import { ApplicationWrapper } from "./aut/ApplicationWrapper";
+import { li, ol, richtext, ul } from "@coremedia-internal/ckeditor5-coremedia-example-data/RichText";
+import "./expect/Expectations";
+
+/**
+ *
+ */
+describe("Document List Feature", () => {
+  // noinspection DuplicatedCode
+  let application: ApplicationWrapper;
+
+  beforeAll(async () => {
+    application = await ApplicationWrapper.start();
+    await application.goto();
+    // Wait for CKEditor to be available prior to executing/continuing the tests.
+    await expect(application).waitForCKEditorToBeAvailable();
+  });
+
+  afterAll(async () => {
+    await application?.shutdown();
+  });
+
+  beforeEach(() => {
+    application.console.open();
+  });
+
+  afterEach(() => {
+    expect(application.console).toHaveNoErrorsOrWarnings();
+    application.console.close();
+  });
+
+  describe("List attributes", () => {
+    //Unfortunately we have to import all parameters with ${} and the element name
+    //is equal to the function name. Therefore, store the element name first as a string.
+    const olString = "ol";
+    const ulString = "ul";
+    it.each`
+      listElement | listElementFunction
+      ${olString} | ${ol}
+      ${ulString} | ${ul}
+    `("$listElement Attributes", async ({ listElement, listElementFunction }) => {
+      const { editor } = application;
+      const { ui } = editor;
+      const editableHandle = await ui.getEditableElement();
+
+      const text = `Lorem Ipsum`;
+      const data = richtext(
+        listElementFunction(li(text), {
+          "class": "anyclass",
+          "dir": "ltr",
+          "xml:lang": "de",
+          "lang": "de",
+        })
+      );
+      const dataView = await editor.setDataAndGetDataView(data);
+
+      // Validate Data-Processing
+      expect(dataView).toContain(text);
+
+      // Validate Editing Downcast
+      const listElementEditable = editableHandle.$(`${listElement}`);
+      const listItem = await (await listElementEditable)?.$("li");
+
+      await expect(listItem).not.toBeNull();
+      await expect(listElementEditable).toMatchAttribute("class", "anyclass");
+      await expect(listElementEditable).toMatchAttribute("dir", "ltr");
+      await expect(listElementEditable).toMatchAttribute("lang", "de");
+    });
+  });
+});

--- a/itest/src/aut/ApplicationWrapper.ts
+++ b/itest/src/aut/ApplicationWrapper.ts
@@ -45,10 +45,25 @@ const startServer = async (): Promise<StartResult> => {
   const { port } = address;
   const baseUrl = new URL(`http://localhost:${port}/`);
   const indexUrl = new URL("/sample/index.html", baseUrl);
+
   const shutdown = async () => {
-    await browser.close();
-    server.close();
-    console.info("Done Browser & Server shutdown triggered.");
+    const start = performance.now();
+
+    const closeServer = new Promise<void>((resolve, reject) => {
+      server.close((err) => {
+        if (!!err) {
+          reject(err);
+        } else {
+          resolve();
+        }
+      });
+    }).catch((e) => console.warn("Failed closing server.", e));
+
+    const closeBrowser = browser.close().catch((e) => console.warn("Failed closing browser.", e));
+
+    await Promise.all([closeServer, closeBrowser]);
+
+    console.info(`Done: Browser & Server shutdown within ${performance.now() - start} ms.`);
   };
 
   console.info(`Server started: Base: ${baseUrl}, Index: ${indexUrl}`);

--- a/packages/ckeditor5-coremedia-example-data/src/RichTextBase.ts
+++ b/packages/ckeditor5-coremedia-example-data/src/RichTextBase.ts
@@ -195,7 +195,7 @@ export interface BlockquoteAttributes extends Attributes {
  * @param attrs - attributes to apply to element
  */
 export const blockquote = (content: Content = "", attrs: BlockquoteAttributes = {}): string => {
-  return nonEmptyElement("pre", content, { ...attrs });
+  return nonEmptyElement("blockquote", content, { ...attrs });
 };
 
 /**


### PR DESCRIPTION
Provide tests for document list integration with possible valid CoreMedia RichText 1.0 structures.

It is important, that no relevant information is lost for any valid CoreMedia RichText read from server.

While testing, we detected one issue, we rate minor for now:

```xml
<ul>
  <li><p>Text</p></li>
</ul>
```

gets the extra paragraph stripped off:

```xml
<ul>
  <li>Text</li>
</ul>
```

The paragraph is not stripped by CKEditor, when it contains additional attributes such as:

```xml
<ul>
  <li><p class="some--class">Text</p></li>
</ul>
```

The tests are meant to provide confidence, that on CKEditor updates, contracts we rely on are still valid.