### PR TITLE
Example App: Fix link balloon position when set on image.

### DIFF
--- a/app/sample/styles.css
+++ b/app/sample/styles.css
@@ -53,6 +53,15 @@
   float: none;
 }
 
+/* Also float surrounding a-tag to set correct link balloon position */
+a:has(> span.float--right) {
+  float: right;
+}
+
+a:has(> span.float--left) {
+  float: left;
+}
+
 /* --------- EXAMPLE DATA ------------------------------------------------------------------------------------------- */
 
 input.error {


### PR DESCRIPTION
Given an image, which is embedded into a link, the link balloon (action view/form view) may have opened misplaced for aligned images (`float--left`, `float--right`).

This pull request addresses this by applying the same alignment to the surrounding anchor tag.

Solution uses the `:has` CSS pseudo-class. Please see [caniuse.com](https://caniuse.com/css-has) browser support and thus possible limitations, if the fix will work in your browser.

A similar fix has to be provided for CoreMedia Studio.