### PR TITLE
Tests: Drag & Drop

### DIFF
--- a/app/src/ckeditor.ts
+++ b/app/src/ckeditor.ts
@@ -52,6 +52,7 @@ import { COREMEDIA_MOCK_CONTENT_PLUGIN } from "@coremedia/ckeditor5-coremedia-st
 
 import { icons } from "@ckeditor/ckeditor5-core";
 import { saveData } from "./dataFacade";
+import MockDragDropPlugin from "@coremedia/ckeditor5-coremedia-studio-integration-mock/content/MockDragDropPlugin";
 
 const {
   //@ts-expect-error We currently have no way to extend icon typing.
@@ -116,6 +117,7 @@ ClassicEditor.create(sourceElement, {
     TableToolbar,
     Underline,
     CoreMediaFontMapper,
+    MockDragDropPlugin,
     MockStudioIntegration,
   ],
   toolbar: {

--- a/itest/src/DragDrop.test.ts
+++ b/itest/src/DragDrop.test.ts
@@ -98,16 +98,64 @@ describe("Drag and Drop", () => {
       const dropTargetSelector = ".ck-content.ck-editor__editable";
       await dragAndDrop(droppableElement, dragElementSelector, dropTargetSelector);
 
+      const { ui } = application.editor;
+      const editableHandle = await ui.getEditableElement();
+      // Validate Editing Downcast
+      await waitForExpect(async () => {
+        const linkElements = await editableHandle.$$("a");
+        await expect(linkElements).toHaveLength(3);
+
+        await expect(linkElements[0]).toHaveText(contentMocks[0].name);
+        await expect(linkElements[1]).toHaveText(contentMocks[1].name);
+        await expect(linkElements[2]).toHaveText(contentMocks[2].name);
+      });
+    });
+
+    it("Should drag three contents (one slow) to the editor, the contents are rendered in the correct order as links", async () => {
+      const firstContentId = 10000;
+      const secondContentId = 10002;
+      const thirdContentId = 10004;
+      const droppableElement: DroppableElement = {
+        label: "Drag And Drop Test",
+        tooltip: "test-element",
+        items: [firstContentId, secondContentId, thirdContentId],
+        classes: ["drag-content"],
+      };
+      const contentMocks = [
+        {
+          id: firstContentId,
+          name: `${droppableElement.label}: ${firstContentId}`,
+        },
+        {
+          id: secondContentId,
+          name: `${droppableElement.label}: ${secondContentId}`,
+          initialDelayMs: 1000,
+        },
+        {
+          id: thirdContentId,
+          name: `${droppableElement.label}: ${thirdContentId}`,
+        },
+      ];
+      await application.mockContent.addContents(contentMocks[0]);
+      await application.mockContent.addContents(contentMocks[1]);
+      await application.mockContent.addContents(contentMocks[2]);
+      await application.mockDragDrop.addDraggableElement(droppableElement);
+
+      //execute drag and drop
+      const dragElementSelector = ".drag-example.drag-content";
+      const dropTargetSelector = ".ck-content.ck-editor__editable";
+      await dragAndDrop(droppableElement, dragElementSelector, dropTargetSelector);
+
       // Validate Editing Downcast
       const { ui } = application.editor;
       const editableHandle = await ui.getEditableElement();
-      const linkElements = await editableHandle.$$("a");
-      await waitForExpect(() => {
-        expect(linkElements).toHaveLength(3);
+      await waitForExpect(async () => {
+        const linkElements = await editableHandle.$$("a");
+        await expect(linkElements).toHaveLength(3);
 
-        expect(linkElements[0]).toHaveText(contentMocks[0].name);
-        expect(linkElements[1]).toHaveText(contentMocks[1].name);
-        expect(linkElements[2]).toHaveText(contentMocks[2].name);
+        await expect(linkElements[0]).toHaveText(contentMocks[0].name);
+        await expect(linkElements[1]).toHaveText(contentMocks[1].name);
+        await expect(linkElements[2]).toHaveText(contentMocks[2].name);
       });
     });
   });

--- a/itest/src/DragDrop.test.ts
+++ b/itest/src/DragDrop.test.ts
@@ -28,7 +28,7 @@ describe("Drag and Drop", () => {
     application.console.close();
   });
 
-  describe("Drag and Drop links", () => {
+  describe("Links", () => {
     it("Should drag a content to the editor, the content is rendered as link", async () => {
       const contentId = 10000;
       const droppableElement: DroppableElement = {
@@ -61,35 +61,35 @@ describe("Drag and Drop", () => {
       const linkElement = await editableHandle.$("a");
       await waitForExpect(() => expect(linkElement).toHaveText(contentMock.name));
     });
-
-    async function dragAndDrop(
-      droppableElement: DroppableElement,
-      dragElementSelector: string,
-      dropTargetSelector: string
-    ): Promise<void> {
-      await page.waitForSelector(dragElementSelector);
-      await page.waitForSelector(dropTargetSelector);
-      const dragElement = page.locator(dragElementSelector);
-      const dropTarget = page.locator(dropTargetSelector);
-
-      await ensureDropAllowed(droppableElement);
-      await dragElement.dragTo(dropTarget);
-    }
-
-    /**
-     * Ensures that the drop is allowed into the CKEditor.
-     *
-     * This contains some implementation knowledge. The "dragover" calculates if the drop is allowed or not.
-     * While the "dragover" is a synchronous event the data retrieval for the calculation is asynchronous.
-     * "dragover" will be executed many times while hovering over the CKEditor and on entering the CKEditor the asynchronous
-     * fetch is triggered. The result will be written to a cache. The next "dragover" will be calculated using those data.
-     *
-     * @param droppableElement -
-     */
-    async function ensureDropAllowed(droppableElement: DroppableElement): Promise<void> {
-      await waitForExpect(() => {
-        expect(application.mockDragDrop.prefillCaches(droppableElement.items)).toBeTruthy();
-      });
-    }
   });
+
+  async function dragAndDrop(
+    droppableElement: DroppableElement,
+    dragElementSelector: string,
+    dropTargetSelector: string
+  ): Promise<void> {
+    await page.waitForSelector(dragElementSelector);
+    await page.waitForSelector(dropTargetSelector);
+    const dragElement = page.locator(dragElementSelector);
+    const dropTarget = page.locator(dropTargetSelector);
+
+    await ensureDropAllowed(droppableElement);
+    await dragElement.dragTo(dropTarget);
+  }
+
+  /**
+   * Ensures that the drop is allowed into the CKEditor.
+   *
+   * This contains some implementation knowledge. The "dragover" calculates if the drop is allowed or not.
+   * While the "dragover" is a synchronous event the data retrieval for the calculation is asynchronous.
+   * "dragover" will be executed many times while hovering over the CKEditor and on entering the CKEditor the asynchronous
+   * fetch is triggered. The result will be written to a cache. The next "dragover" will be calculated using those data.
+   *
+   * @param droppableElement -
+   */
+  async function ensureDropAllowed(droppableElement: DroppableElement): Promise<void> {
+    await waitForExpect(() => {
+      expect(application.mockDragDrop.prefillCaches(droppableElement.items)).toBeTruthy();
+    });
+  }
 });

--- a/itest/src/DragDrop.test.ts
+++ b/itest/src/DragDrop.test.ts
@@ -10,13 +10,13 @@ import {
   PNG_RED_240x135,
 } from "@coremedia/ckeditor5-coremedia-studio-integration-mock/content/MockFixtures";
 
-const oneLink = [
+const oneLink: MockContentConfig[] = [
   {
     id: 10000,
     name: "Document 10000",
   },
 ];
-const multipleLinksIncludingSlow = [
+const multipleLinksIncludingSlow: MockContentConfig[] = [
   {
     id: 10002,
     name: "Document: 10002",
@@ -31,7 +31,7 @@ const multipleLinksIncludingSlow = [
     name: "Document 10006",
   },
 ];
-const multipleLinks = [
+const multipleLinks: MockContentConfig[] = [
   {
     id: 10008,
     name: "Document: 10008",
@@ -46,7 +46,7 @@ const multipleLinks = [
   },
 ];
 
-const oneImage = [
+const oneImage: MockContentConfig[] = [
   {
     id: 100014,
     name: "Document 100014",
@@ -55,7 +55,7 @@ const oneImage = [
     linkable: true,
   },
 ];
-const multipleImages = [
+const multipleImages: MockContentConfig[] = [
   {
     id: 100016,
     name: "Document 100016",
@@ -78,7 +78,7 @@ const multipleImages = [
     linkable: true,
   },
 ];
-const multipleImagesSlow = [
+const multipleImagesSlow: MockContentConfig[] = [
   {
     id: 100022,
     name: "Document 100022",

--- a/itest/src/DragDrop.test.ts
+++ b/itest/src/DragDrop.test.ts
@@ -140,7 +140,7 @@ describe("Drag and Drop", () => {
     it.each`
       dragElementClass         | contentMocks
       ${"one-link"}            | ${oneLink}
-      ${"mulitple-links-slow"} | ${multipleLinksIncludingSlow}
+      ${"multiple-links-slow"} | ${multipleLinksIncludingSlow}
       ${"multiple-links"}      | ${multipleLinks}
     `(
       "[$#]: Should drag and drop $contentMocks.length non embeddable contents as links.",

--- a/itest/src/DragDrop.test.ts
+++ b/itest/src/DragDrop.test.ts
@@ -16,6 +16,7 @@ const oneLink: MockContentConfig[] = [
     name: "Document 10000",
   },
 ];
+
 const multipleLinksIncludingSlow: MockContentConfig[] = [
   {
     id: 10002,
@@ -31,6 +32,7 @@ const multipleLinksIncludingSlow: MockContentConfig[] = [
     name: "Document 10006",
   },
 ];
+
 const multipleLinks: MockContentConfig[] = [
   {
     id: 10008,
@@ -55,6 +57,7 @@ const oneImage: MockContentConfig[] = [
     linkable: true,
   },
 ];
+
 const multipleImages: MockContentConfig[] = [
   {
     id: 100016,
@@ -78,6 +81,7 @@ const multipleImages: MockContentConfig[] = [
     linkable: true,
   },
 ];
+
 const multipleImagesSlow: MockContentConfig[] = [
   {
     id: 100022,

--- a/itest/src/DragDrop.test.ts
+++ b/itest/src/DragDrop.test.ts
@@ -1,0 +1,95 @@
+import { ApplicationWrapper } from "./aut/ApplicationWrapper";
+import { richtext } from "@coremedia-internal/ckeditor5-coremedia-example-data/RichText";
+import "./expect/Expectations";
+import { DroppableElement } from "@coremedia/ckeditor5-coremedia-studio-integration-mock/content/MockDragDropPlugin";
+import waitForExpect from "wait-for-expect";
+
+describe("Drag and Drop", () => {
+  // noinspection DuplicatedCode
+  let application: ApplicationWrapper;
+
+  beforeAll(async () => {
+    application = await ApplicationWrapper.start();
+    await application.goto();
+    // Wait for CKEditor to be available prior to executing/continuing the tests.
+    await expect(application).waitForCKEditorToBeAvailable();
+  });
+
+  afterAll(async () => {
+    await application?.shutdown();
+  });
+
+  beforeEach(() => {
+    application.console.open();
+  });
+
+  afterEach(() => {
+    expect(application.console).toHaveNoErrorsOrWarnings();
+    application.console.close();
+  });
+
+  describe("Drag and Drop links", () => {
+    it("Should drag a content to the editor, the content is rendered as link", async () => {
+      const contentId = 10000;
+      const droppableElement: DroppableElement = {
+        label: "Drag And Drop Test",
+        tooltip: "test-element",
+        items: [contentId],
+        classes: ["drag-content"],
+      };
+      const contentMock = {
+        id: contentId,
+        name: `${droppableElement.label}: ${contentId}`,
+      };
+      //Add contents and create the draggable element
+      await application.mockContent.addContents(contentMock);
+      await application.mockDragDrop.addDraggableElement(droppableElement);
+
+      //setup initial data
+      const initialData = richtext();
+      const { editor } = application;
+      await editor.setDataAndGetDataView(initialData);
+
+      //execute drag and drop
+      const dragElementSelector = ".drag-example.drag-content";
+      const dropTargetSelector = ".ck-content.ck-editor__editable";
+      await dragAndDrop(droppableElement, dragElementSelector, dropTargetSelector);
+
+      // Validate Editing Downcast
+      const { ui } = editor;
+      const editableHandle = await ui.getEditableElement();
+      const linkElement = await editableHandle.$("a");
+      await waitForExpect(() => expect(linkElement).toHaveText(contentMock.name));
+    });
+
+    async function dragAndDrop(
+      droppableElement: DroppableElement,
+      dragElementSelector: string,
+      dropTargetSelector: string
+    ): Promise<void> {
+      await page.waitForSelector(dragElementSelector);
+      await page.waitForSelector(dropTargetSelector);
+      const dragElement = page.locator(dragElementSelector);
+      const dropTarget = page.locator(dropTargetSelector);
+
+      await ensureDropAllowed(droppableElement);
+      await dragElement.dragTo(dropTarget);
+    }
+
+    /**
+     * Ensures that the drop is allowed into the CKEditor.
+     *
+     * This contains some implementation knowledge. The "dragover" calculates if the drop is allowed or not.
+     * While the "dragover" is a synchronous event the data retrieval for the calculation is asynchronous.
+     * "dragover" will be executed many times while hovering over the CKEditor and on entering the CKEditor the asynchronous
+     * fetch is triggered. The result will be written to a cache. The next "dragover" will be calculated using those data.
+     *
+     * @param droppableElement -
+     */
+    async function ensureDropAllowed(droppableElement: DroppableElement): Promise<void> {
+      await waitForExpect(() => {
+        expect(application.mockDragDrop.prefillCaches(droppableElement.items)).toBeTruthy();
+      });
+    }
+  });
+});

--- a/itest/src/DragDrop.test.ts
+++ b/itest/src/DragDrop.test.ts
@@ -63,7 +63,9 @@ describe("Drag and Drop", () => {
       const linkElement = await editableHandle.$("a");
       await waitForExpect(() => expect(linkElement).toHaveText(contentMock.name));
     });
+  });
 
+  describe("Images", () => {
     it("Should drag an image-content to the editor, the content is rendered as an image", async () => {
       const contentId = 10002;
       const droppableElement: DroppableElement = {

--- a/itest/src/DragDrop.test.ts
+++ b/itest/src/DragDrop.test.ts
@@ -63,6 +63,53 @@ describe("Drag and Drop", () => {
       const linkElement = await editableHandle.$("a");
       await waitForExpect(() => expect(linkElement).toHaveText(contentMock.name));
     });
+
+    it("Should drag three contents to the editor, the contents are rendered in the correct order as links", async () => {
+      const firstContentId = 10000;
+      const secondContentId = 10002;
+      const thirdContentId = 10004;
+      const droppableElement: DroppableElement = {
+        label: "Drag And Drop Test",
+        tooltip: "test-element",
+        items: [firstContentId, secondContentId, thirdContentId],
+        classes: ["drag-content"],
+      };
+      const contentMocks = [
+        {
+          id: firstContentId,
+          name: `${droppableElement.label}: ${firstContentId}`,
+        },
+        {
+          id: secondContentId,
+          name: `${droppableElement.label}: ${secondContentId}`,
+        },
+        {
+          id: thirdContentId,
+          name: `${droppableElement.label}: ${thirdContentId}`,
+        },
+      ];
+      await application.mockContent.addContents(contentMocks[0]);
+      await application.mockContent.addContents(contentMocks[1]);
+      await application.mockContent.addContents(contentMocks[2]);
+      await application.mockDragDrop.addDraggableElement(droppableElement);
+
+      //execute drag and drop
+      const dragElementSelector = ".drag-example.drag-content";
+      const dropTargetSelector = ".ck-content.ck-editor__editable";
+      await dragAndDrop(droppableElement, dragElementSelector, dropTargetSelector);
+
+      // Validate Editing Downcast
+      const { ui } = application.editor;
+      const editableHandle = await ui.getEditableElement();
+      const linkElements = await editableHandle.$$("a");
+      await waitForExpect(() => {
+        expect(linkElements).toHaveLength(3);
+
+        expect(linkElements[0]).toHaveText(contentMocks[0].name);
+        expect(linkElements[1]).toHaveText(contentMocks[1].name);
+        expect(linkElements[2]).toHaveText(contentMocks[2].name);
+      });
+    });
   });
 
   describe("Images", () => {
@@ -134,8 +181,9 @@ describe("Drag and Drop", () => {
    * @param droppableElement -
    */
   async function ensureDropAllowed(droppableElement: DroppableElement): Promise<void> {
-    await waitForExpect(() => {
-      expect(application.mockDragDrop.prefillCaches(droppableElement.items)).toBeTruthy();
+    await waitForExpect(async () => {
+      const actual = await application.mockDragDrop.prefillCaches(droppableElement.items);
+      expect(actual).toBeTruthy();
     });
   }
 });

--- a/itest/src/aut/ApplicationWrapper.ts
+++ b/itest/src/aut/ApplicationWrapper.ts
@@ -8,6 +8,7 @@ import { AddressInfo } from "net";
 import { ApplicationConsole } from "./ApplicationConsole";
 import { MockContentPluginWrapper } from "./MockContentPluginWrapper";
 import { MockServiceAgentPluginWrapper } from "./services/MockServiceAgentPluginWrapper";
+import { MockDragDropPluginWrapper } from "./MockDragDropPluginWrapper";
 
 /**
  * Represents result from starting the server.
@@ -120,6 +121,10 @@ export class ApplicationWrapper {
    */
   get mockContent(): MockContentPluginWrapper {
     return MockContentPluginWrapper.fromClassicEditor(this.editor);
+  }
+
+  get mockDragDrop(): MockDragDropPluginWrapper {
+    return MockDragDropPluginWrapper.fromClassicEditor(this.editor);
   }
 
   get mockServiceAgent(): MockServiceAgentPluginWrapper {

--- a/itest/src/aut/MockDragDropPluginWrapper.ts
+++ b/itest/src/aut/MockDragDropPluginWrapper.ts
@@ -1,0 +1,43 @@
+import { JSWrapper } from "./JSWrapper";
+import { ClassicEditorWrapper } from "./ClassicEditorWrapper";
+import MockDragDropPlugin, {
+  DroppableElement,
+} from "@coremedia/ckeditor5-coremedia-studio-integration-mock/content/MockDragDropPlugin";
+
+/**
+ * Provides access to the `MockDragDropPlugin`.
+ */
+export class MockDragDropPluginWrapper extends JSWrapper<MockDragDropPlugin> {
+  async addDraggableElement(data: DroppableElement): Promise<void> {
+    await this.evaluate((p, data) => {
+      const htmlDivElement = p.createDragDivElement(data);
+      window.document.body.append(htmlDivElement);
+    }, data);
+  }
+
+  async prefillCaches(contentIds: number[]): Promise<boolean> {
+    return this.evaluate((plugin: MockDragDropPlugin, contentIds): boolean => {
+      return plugin.prefillCaches(contentIds);
+    }, contentIds);
+  }
+
+  /**
+   * Provides access to EditorUI via Editor.
+   * @param wrapper - editor wrapper
+   */
+  static fromClassicEditor(wrapper: ClassicEditorWrapper) {
+    return new MockDragDropPluginWrapper(
+      wrapper.evaluateHandle((editor, pluginName) => {
+        if (!editor.plugins.has(pluginName)) {
+          const available = [...editor.plugins]
+            .map(([t, p]) => t.pluginName || `noname:${p.constructor.name}`)
+            .join(", ");
+          throw new Error(`Plugin ${pluginName} not available. Available plugins: ${available}`);
+        }
+        // We need to access the plugin via its name rather than via descriptor,
+        // as the descriptor is unknown in remote context.
+        return editor.plugins.get(pluginName) as MockDragDropPlugin;
+      }, MockDragDropPlugin.pluginName)
+    );
+  }
+}

--- a/packages/ckeditor5-coremedia-example-data/src/tsconfig.json
+++ b/packages/ckeditor5-coremedia-example-data/src/tsconfig.json
@@ -5,7 +5,7 @@
     "outDir": "../dist",
     "emitDeclarationOnly": true,
     "declaration": true,
-    "declarationMap": true
+    "declarationMap": true,
   },
   "extends": "../../../tsconfig.json"
 }

--- a/packages/ckeditor5-coremedia-studio-integration-mock/src/content/MockDragDropPlugin.ts
+++ b/packages/ckeditor5-coremedia-studio-integration-mock/src/content/MockDragDropPlugin.ts
@@ -2,6 +2,8 @@ import Plugin from "@ckeditor/ckeditor5-core/src/plugin";
 import { reportInitEnd, reportInitStart } from "@coremedia/ckeditor5-core-common/Plugins";
 import { serviceAgent } from "@coremedia/service-agent";
 import MockDragDropService from "./MockDragDropService";
+import DragDropAsyncSupport from "@coremedia/ckeditor5-coremedia-studio-integration/content/DragDropAsyncSupport";
+import { contentUriPath } from "@coremedia/ckeditor5-coremedia-studio-integration/content/UriPath";
 
 /**
  * Describes a div-element which can be created by this plugin.
@@ -50,6 +52,24 @@ class MockDragDropPlugin extends Plugin {
     dragDiv.addEventListener("dragstart", MockDragDropPlugin.#setDragData);
     dragDiv.addEventListener("dragend", MockDragDropPlugin.#removeDropData);
     return dragDiv;
+  }
+
+  /**
+   * Fills the caches for the drag and drop.
+   *
+   * While the "dragover" event is executed synchronously, we have
+   * an asynchronous service-agent call to calculate the drop allowed.
+   *
+   * To ensure in tests that the drop is allowed, the cache can be filled before
+   * executing the drop.
+   *
+   * @param contentIds - the ids to fill the cache for.
+   */
+  prefillCaches(contentIds: number[]): boolean {
+    const uriPaths = contentIds.map((contentId) => contentUriPath(contentId));
+    return uriPaths.every((uriPath) => {
+      return DragDropAsyncSupport.isLinkable(uriPath);
+    });
   }
 
   /**

--- a/packages/ckeditor5-coremedia-studio-integration-mock/src/content/MockDragDropPlugin.ts
+++ b/packages/ckeditor5-coremedia-studio-integration-mock/src/content/MockDragDropPlugin.ts
@@ -6,9 +6,9 @@ import DragDropAsyncSupport from "@coremedia/ckeditor5-coremedia-studio-integrat
 import { contentUriPath } from "@coremedia/ckeditor5-coremedia-studio-integration/content/UriPath";
 
 /**
- * Describes a div-element which can be created by this plugin.
- * An DroppableElement contains all data which are necessary to make the created
- * div-element drag & drop ready.
+ * Describes a div-element that can be created by this plugin.
+ * A `DroppableElement` contains all data that are necessary to make the created
+ * div-element drag &amp; drop ready.
  */
 export interface DroppableElement {
   /**
@@ -37,7 +37,7 @@ const PLUGIN_NAME = "MockDragDrop";
 class MockDragDropPlugin extends Plugin {
   static readonly pluginName: string = PLUGIN_NAME;
 
-  init(): Promise<void> | void {
+  init(): void {
     const initInformation = reportInitStart(this);
     reportInitEnd(initInformation);
   }
@@ -48,7 +48,7 @@ class MockDragDropPlugin extends Plugin {
     dragDiv.draggable = true;
     dragDiv.textContent = data.label || "Unset";
     dragDiv.dataset.cmuripath = MockDragDropPlugin.#generateUriPathCsv(data.items || []);
-    dragDiv.title = data.tooltip + " (" + dragDiv.dataset.cmuripath + ")";
+    dragDiv.title = `${data.tooltip} (${dragDiv.dataset.cmuripath})`;
     dragDiv.addEventListener("dragstart", MockDragDropPlugin.#setDragData);
     dragDiv.addEventListener("dragend", MockDragDropPlugin.#removeDropData);
     return dragDiv;
@@ -73,7 +73,8 @@ class MockDragDropPlugin extends Plugin {
   }
 
   /**
-   * Set the drag data stored in the attribute data-cmuripath to the dragEvent.dataTransfer and to the dragDropService in studio.
+   * Set the drag data stored in the attribute data-cmuripath to the
+   * `dragEvent.dataTransfer` and to the dragDropService in studio.
    *
    * @param dragEvent the drag event
    */

--- a/packages/ckeditor5-coremedia-studio-integration-mock/src/content/MockDragDropPlugin.ts
+++ b/packages/ckeditor5-coremedia-studio-integration-mock/src/content/MockDragDropPlugin.ts
@@ -1,0 +1,108 @@
+import Plugin from "@ckeditor/ckeditor5-core/src/plugin";
+import { reportInitEnd, reportInitStart } from "@coremedia/ckeditor5-core-common/Plugins";
+import { serviceAgent } from "@coremedia/service-agent";
+import MockDragDropService from "./MockDragDropService";
+
+/**
+ * Describes a div-element which can be created by this plugin.
+ * An DroppableElement contains all data which are necessary to make the created
+ * div-element drag & drop ready.
+ */
+export interface DroppableElement {
+  /**
+   * The visible text on the div element.
+   */
+  label: string;
+  /**
+   * the tooltip on hover of the element
+   */
+  tooltip: string;
+  /**
+   * classes added to the div element.
+   */
+  classes: string[];
+  /**
+   * content ids to create the drag information for studio from.
+   */
+  items: number[];
+}
+
+const PLUGIN_NAME = "MockDragDrop";
+
+/**
+ * A Plugin to create drag & drop mock data inside the example app and tests.
+ */
+class MockDragDropPlugin extends Plugin {
+  static readonly pluginName: string = PLUGIN_NAME;
+
+  init(): Promise<void> | void {
+    const initInformation = reportInitStart(this);
+    reportInitEnd(initInformation);
+  }
+
+  createDragDivElement(data: DroppableElement): HTMLDivElement {
+    const dragDiv = document.createElement("div");
+    dragDiv.classList.add("drag-example", ...(data.classes || []));
+    dragDiv.draggable = true;
+    dragDiv.textContent = data.label || "Unset";
+    dragDiv.dataset.cmuripath = MockDragDropPlugin.#generateUriPathCsv(data.items || []);
+    dragDiv.title = data.tooltip + " (" + dragDiv.dataset.cmuripath + ")";
+    dragDiv.addEventListener("dragstart", MockDragDropPlugin.#setDragData);
+    dragDiv.addEventListener("dragend", MockDragDropPlugin.#removeDropData);
+    return dragDiv;
+  }
+
+  /**
+   * Set the drag data stored in the attribute data-cmuripath to the dragEvent.dataTransfer and to the dragDropService in studio.
+   *
+   * @param dragEvent the drag event
+   */
+  static #setDragData(dragEvent: DragEvent) {
+    const dragEventTarget = dragEvent.target as HTMLElement;
+    const contentId = dragEventTarget.getAttribute("data-cmuripath");
+    if (contentId) {
+      const idsArray = contentId.split(",");
+      const dragDropService = new MockDragDropService();
+      dragDropService.dragData = JSON.stringify(MockDragDropPlugin.#contentDragData(...idsArray));
+      serviceAgent.registerService(dragDropService);
+      dragEvent.dataTransfer?.setData("cm/uri-list", JSON.stringify(MockDragDropPlugin.#contentList(...idsArray)));
+      dragEvent.dataTransfer?.setData("text", JSON.stringify(MockDragDropPlugin.#contentList(...idsArray)));
+      return;
+    }
+    const text = dragEventTarget.childNodes[0].textContent;
+    if (text) {
+      dragEvent.dataTransfer?.setData("text/plain", text);
+    }
+  }
+
+  /**
+   * Unregister the old dragDropService.
+   */
+  static #removeDropData(): void {
+    serviceAgent.unregisterServices("dragDropService");
+  }
+
+  static #contentList(...ids: string[]): { $Ref: string }[] {
+    return ids.map((id) => {
+      return {
+        $Ref: id,
+      };
+    });
+  }
+
+  static #contentDragData(...ids: string[]): { contents: { $Ref: string }[] } {
+    return {
+      contents: MockDragDropPlugin.#contentList(...ids),
+    };
+  }
+
+  static #generateUriPath(item: number): string {
+    return `content/${item}`;
+  }
+
+  static #generateUriPathCsv(items: number[]): string {
+    return items.map((item) => MockDragDropPlugin.#generateUriPath(item)).join(",");
+  }
+}
+
+export default MockDragDropPlugin;


### PR DESCRIPTION
Provides a bunch of tests for dragging and dropping contents directly into the editing view of CKEditor.

Introduces `MockDragDropPlugin` as extension to example application, to easily create draggable examples right from the tests. These draggable examples mock other drag and drop sources like the library in CoreMedia Studio.