### PR TITLE
Security: Change the way how to decode HTML Entities.

### DIFF
--- a/packages/ckeditor5-font-mapper/src/FontMapping.ts
+++ b/packages/ckeditor5-font-mapper/src/FontMapping.ts
@@ -28,7 +28,7 @@ export type Mode = "replace" | "append";
 export class FontMapping {
   static readonly #logger = LoggerProvider.getLogger("FontMapper");
   #map: FontMap;
-  #DECODE_ELEMENT_HELP = document.createElement("div");
+  #DECODE_ELEMENT_HELP = document.createElement("textarea");
 
   constructor(map: FontMap) {
     this.#map = FontMapping.#mergeFontMaps(htmlEncodingMap, map);
@@ -109,7 +109,7 @@ export class FontMapping {
    */
   #decodeHtmlEntities(inputString: string): string {
     this.#DECODE_ELEMENT_HELP.innerHTML = inputString;
-    const textContent = this.#DECODE_ELEMENT_HELP.textContent;
+    const textContent = this.#DECODE_ELEMENT_HELP.value;
     if (!textContent) {
       // see https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent
       throw new Error("Error during decodeHtmlEntities: HTMLDivElement has no textContent");

--- a/packages/ckeditor5-font-mapper/src/FontMapping.ts
+++ b/packages/ckeditor5-font-mapper/src/FontMapping.ts
@@ -108,6 +108,8 @@ export class FontMapping {
    * @returns the decoded string
    */
   #decodeHtmlEntities(inputString: string): string {
+    //This is mentioned by CodeQL as security vulnerability but using a textarea element it can't be misused.
+    //Therefore, the vulnerability is ignored.
     this.#DECODE_ELEMENT_HELP.innerHTML = inputString;
     const textContent = this.#DECODE_ELEMENT_HELP.value;
     if (!textContent) {


### PR DESCRIPTION
The versions can be compared by executing the following code snippets in the developer console.

Old version:

````
document.createElement("div").innerHTML = '<img src="nonexistent_image" onerror="alert(1337)">'
````
Result in Chrome: 

> 118:1 Refused to execute inline event handler because it violates the following Content Security Policy directive: "script-src github.githubassets.com". Either the 'unsafe-inline' keyword, a hash ('sha256-...'), or a nonce ('nonce-...') is required to enable inline execution. Note that hashes do not apply to event handlers, style attributes and javascript: navigations unless the 'unsafe-hashes' keyword is present.

New version:

````
document.createElement("textarea").innerHTML = '<img src="nonexistent_image" onerror="alert(1337)">'
````

Result in Chrome:
> '< img src="nonexistent_image" onerror="alert(1337)">'
