### PR TITLE
Paste Button: Handle expanded ranges

### DIFF
--- a/packages/ckeditor5-coremedia-content-clipboard/src/ContentMarkers.ts
+++ b/packages/ckeditor5-coremedia-content-clipboard/src/ContentMarkers.ts
@@ -6,7 +6,7 @@ import { ContentClipboardMarkerDataUtils } from "./ContentClipboardMarkerDataUti
 import LoggerProvider from "@coremedia/ckeditor5-logging/logging/LoggerProvider";
 import { serviceAgent } from "@coremedia/service-agent";
 import { createRichtextConfigurationServiceDescriptor } from "@coremedia/ckeditor5-coremedia-studio-integration/content/RichtextConfigurationServiceDescriptor";
-import { Model } from "@ckeditor/ckeditor5-engine";
+import type { Model } from "@ckeditor/ckeditor5-engine";
 
 const logger = LoggerProvider.getLogger("ContentMarkers");
 

--- a/packages/ckeditor5-coremedia-content-clipboard/src/ContentMarkers.ts
+++ b/packages/ckeditor5-coremedia-content-clipboard/src/ContentMarkers.ts
@@ -74,7 +74,7 @@ export const insertContentMarkers = (editor: Editor, targetRange: ModelRange, co
 };
 
 /**
- * Handles expanded ranges by removing everything inside the range and create a
+ * Handles expanded ranges by removing everything inside the range and creates a
  * collapsed range at the start of the expanded range.
  * If the given range is already collapsed the range will be returned without any changes.
  *


### PR DESCRIPTION
When something is selected in the editor and the paste button is used the selected content has to be removed before inserting.