### PR TITLE
fix(data-processor): Fixes TypeError "is not iterable"

### DIFF
--- a/packages/ckeditor5-coremedia-richtext/src/CoreMediaRichTextConfig.ts
+++ b/packages/ckeditor5-coremedia-richtext/src/CoreMediaRichTextConfig.ts
@@ -43,7 +43,7 @@ export interface CommonCoreMediaRichTextConfig extends CompatibilityConfig {
 
 export interface LatestCoreMediaRichTextConfig extends CommonCoreMediaRichTextConfig {
   readonly compatibility: "latest";
-  readonly rules: RuleConfig[];
+  readonly rules?: RuleConfig[];
 }
 
 const isLatestCoreMediaRichTextConfig = (value: unknown): value is LatestCoreMediaRichTextConfig => {

--- a/packages/ckeditor5-coremedia-richtext/src/RichTextDataProcessor.ts
+++ b/packages/ckeditor5-coremedia-richtext/src/RichTextDataProcessor.ts
@@ -110,7 +110,7 @@ class RichTextDataProcessor implements DataProcessor {
 
     this.#strictness = config.strictness;
 
-    this.addRules([...defaultRules, ...config.rules]);
+    this.addRules([...defaultRules, ...(config.rules ?? [])]);
 
     /*
      * We need to mark xdiff:span as elements preserving spaces. Otherwise,


### PR DESCRIPTION
Fixes exception when no rules got specified in configuration:

```
RichTextDataProcessor: Uncaught (in promise) TypeError: _config.rules is not iterable
```

And, to be able to detect such issues, marked `rules` in `LatestCoreMediaRichTextConfig` as optional  (which is the same as for `V10CoreMediaRichTextConfig`).