### PR TITLE
fix(data-processor): Fixes isDebugEnabled on undefined

### DIFF
--- a/packages/ckeditor5-coremedia-richtext/src/RichTextDataProcessor.ts
+++ b/packages/ckeditor5-coremedia-richtext/src/RichTextDataProcessor.ts
@@ -201,9 +201,9 @@ class RichTextDataProcessor implements DataProcessor {
     const logger = RichTextDataProcessor.#logger;
     if (logger.isDebugEnabled()) {
       logger.debug(`toData Rules (${this.#toDataRules.length}):`);
-      this.#toDataConversionListener.dumpRules(logger.debug, "\t");
+      this.#toDataConversionListener.dumpRules(logger, "\t");
       logger.debug(`toView Rules (${this.#toViewRules.length}):`);
-      this.#toViewConversionListener.dumpRules(logger.debug, "\t");
+      this.#toViewConversionListener.dumpRules(logger, "\t");
     }
   }
 

--- a/packages/ckeditor5-dom-converter/src/RuleBasedConversionListener.ts
+++ b/packages/ckeditor5-dom-converter/src/RuleBasedConversionListener.ts
@@ -2,6 +2,7 @@ import { skip, Skip } from "./Signals";
 import { ConversionContext } from "./ConversionContext";
 import { byPriority, RuleSection, SortedRuleSection } from "./Rule";
 import { ConversionListener } from "./ConversionListener";
+import Logger from "@coremedia/ckeditor5-logging/logging/Logger";
 
 /**
  * Rule based HTML DOM Converter.
@@ -34,14 +35,14 @@ export class RuleBasedConversionListener implements ConversionListener {
   /**
    * Dumps the IDs of configured rules.
    *
-   * @param writer - writer to write rule IDs to
+   * @param logger - logger to write debug information to
    * @param indent - optional indent
    */
-  dumpRules(writer: (...data: unknown[]) => void = console.debug, indent = ""): void {
+  dumpRules(logger: Logger, indent = ""): void {
     this.#rules
       .map((section) => section.id)
       .forEach((id) => {
-        writer(`${indent}${id}`);
+        logger.debug(`${indent}${id}`);
       });
   }
 


### PR DESCRIPTION
Recent refactoring of rule based processing introduced a bug, that prevented enabling ckdebug mode.

Switching to explicit `Logger` reference instead of trying to pass just some method-handles.