### PR TITLE
fix(data-processor): Fixes Debugging Output

### DIFF
--- a/packages/ckeditor5-dom-converter/src/HtmlDomConverter.ts
+++ b/packages/ckeditor5-dom-converter/src/HtmlDomConverter.ts
@@ -125,7 +125,7 @@ export class HtmlDomConverter {
     if (logger.isDebugEnabled()) {
       logger.debug(`convert(${originalNode.nodeName}); Stage: imported`, {
         input: originalNodeString,
-        imported: nodeToString(originalNode),
+        imported: nodeToString(result === skip ? undefined : result),
       });
     }
 


### PR DESCRIPTION
"imported" output wrongly outputs the incoming node as result, but it is the resulting node, which needs to be logged instead.