### PR TITLE
fix(images): Catch unwanted xlink-href attributes

### DIFF
--- a/itest/src/Images.test.ts
+++ b/itest/src/Images.test.ts
@@ -121,6 +121,37 @@ describe("Image Features", () => {
     });
   });
 
+  describe("Image with invalid xlink:href", () => {
+    it("Should correctly render broken image with empty src", async () => {
+      const { currentTestName } = expect.getState();
+      const name = currentTestName ?? "Unknown Test";
+      const { editor } = application;
+      const { ui } = editor;
+
+      const data = richtext(
+        p(
+          img({
+            "alt": name,
+            "xlink:href": "",
+          })
+        )
+      );
+
+      await editor.setDataAndGetDataView(data);
+      const editableHandle = await ui.getEditableElement();
+
+      await expect(editableHandle).toHaveSelector("img");
+
+      const imgHandleWithAltAttribute = await editableHandle.$("img[alt]");
+      // There is an image with an alt attribute
+      await waitForExpect(() => expect(imgHandleWithAltAttribute).not.toBeNull());
+
+      const imgHandleWithSrcAttribute = await editableHandle.$("img[src]");
+      // There is no image with a src attribute
+      await waitForExpect(() => expect(imgHandleWithSrcAttribute).toBeNull());
+    });
+  });
+
   describe("Image Alignment", () => {
     it("Should correctly set Image Alignment", async () => {
       const { currentTestName } = expect.getState();
@@ -200,7 +231,7 @@ describe("Image Features", () => {
       expect(await mockWorkAreaService.getLastOpenedEntities()).toEqual(["content/42"]);
     });
 
-    it("Should not be able to trigger open in tab for image from ballon", async () => {
+    it("Should not be able to trigger open in tab for image from balloon", async () => {
       const { currentTestName } = expect.getState();
       const name = currentTestName ?? "Unknown Test";
       const { editor, mockContent } = application;

--- a/packages/ckeditor5-coremedia-images/src/ContentImageEditingPlugin.ts
+++ b/packages/ckeditor5-coremedia-images/src/ContentImageEditingPlugin.ts
@@ -11,6 +11,8 @@ import {
   reportInitStart,
 } from "@coremedia/ckeditor5-core-common/Plugins";
 import { OpenInTabCommand } from "@coremedia/ckeditor5-coremedia-content/commands/OpenInTabCommand";
+import Logger from "@coremedia/ckeditor5-logging/logging/Logger";
+import LoggerProvider from "@coremedia/ckeditor5-logging/logging/LoggerProvider";
 
 /**
  * Plugin to support images from CoreMedia RichText.
@@ -23,6 +25,7 @@ import { OpenInTabCommand } from "@coremedia/ckeditor5-coremedia-content/command
  */
 export default class ContentImageEditingPlugin extends Plugin {
   static readonly pluginName: string = "ContentImageEditingPlugin";
+  static readonly #logger: Logger = LoggerProvider.getLogger(ContentImageEditingPlugin.pluginName);
 
   static readonly IMAGE_INLINE_MODEL_ELEMENT_NAME = "imageInline";
   static readonly IMAGE_INLINE_VIEW_ELEMENT_NAME = "img";
@@ -93,7 +96,7 @@ export default class ContentImageEditingPlugin extends Plugin {
     });
 
     //For editing-view the xlink-href attribute has to be converted to a src-attribute.
-    editor.conversion.for("editingDowncast").add(editingDowncastXlinkHref(editor, modelElementName));
+    editor.conversion.for("editingDowncast").add(editingDowncastXlinkHref(editor, modelElementName, ContentImageEditingPlugin.#logger));
   }
 
   /**

--- a/packages/ckeditor5-coremedia-images/src/ContentImageEditingPlugin.ts
+++ b/packages/ckeditor5-coremedia-images/src/ContentImageEditingPlugin.ts
@@ -96,7 +96,9 @@ export default class ContentImageEditingPlugin extends Plugin {
     });
 
     //For editing-view the xlink-href attribute has to be converted to a src-attribute.
-    editor.conversion.for("editingDowncast").add(editingDowncastXlinkHref(editor, modelElementName, ContentImageEditingPlugin.#logger));
+    editor.conversion
+      .for("editingDowncast")
+      .add(editingDowncastXlinkHref(editor, modelElementName, ContentImageEditingPlugin.#logger));
   }
 
   /**

--- a/packages/ckeditor5-coremedia-images/src/converters.ts
+++ b/packages/ckeditor5-coremedia-images/src/converters.ts
@@ -17,6 +17,7 @@ import ModelBoundSubscriptionPlugin from "./ModelBoundSubscriptionPlugin";
 import "../theme/loadmask.css";
 import "./lang/contentimage";
 import { ifPlugin, optionalPluginNotFound } from "@coremedia/ckeditor5-core-common/Plugins";
+import Logger from "@coremedia/ckeditor5-logging/logging/Logger";
 
 const LOGGER = LoggerProvider.getLogger(IMAGE_PLUGIN_NAME);
 
@@ -76,7 +77,7 @@ export const preventUpcastImageSrc =
  * @param modelElementName - the element name to convert
  */
 export const editingDowncastXlinkHref =
-  (editor: Editor, modelElementName: string): DowncastConversionHelperFunction =>
+  (editor: Editor, modelElementName: string, logger: Logger): DowncastConversionHelperFunction =>
   (dispatcher: DowncastDispatcher) => {
     dispatcher.on(`attribute:xlink-href:${modelElementName}`, (eventInfo: EventInfo, data: DowncastEventData): void => {
       if (!data.attributeNewValue) {
@@ -85,11 +86,16 @@ export const editingDowncastXlinkHref =
         return;
       }
       // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-      onXlinkHrefEditingDowncast(editor, eventInfo, data);
+      onXlinkHrefEditingDowncast(editor, eventInfo, data, logger);
     });
   };
 
-const onXlinkHrefEditingDowncast = (editor: Editor, eventInfo: EventInfo, data: DowncastEventData): void => {
+const onXlinkHrefEditingDowncast = (
+  editor: Editor,
+  eventInfo: EventInfo,
+  data: DowncastEventData,
+  logger: Logger
+): void => {
   const spinnerPreviewAttributes = createSpinnerImagePreviewAttributes(editor);
   updateImagePreviewAttributes(editor, data.item, spinnerPreviewAttributes, true);
 
@@ -106,6 +112,7 @@ const onXlinkHrefEditingDowncast = (editor: Editor, eventInfo: EventInfo, data: 
     // toUriPath() might throw an exception, but an unresolvable
     // uriPath should not result in an error, which would break the editor.
     // Therefore: Return early. An endless loading spinner will be displayed as a result.
+    logger.debug("Cannot resolve valid uriPath from xlink-href attribute:", xlinkHref);
     return;
   }
 

--- a/packages/ckeditor5-coremedia-images/src/converters.ts
+++ b/packages/ckeditor5-coremedia-images/src/converters.ts
@@ -75,6 +75,7 @@ export const preventUpcastImageSrc =
  *
  * @param editor - the editor instance
  * @param modelElementName - the element name to convert
+ * @param logger - the logger
  */
 export const editingDowncastXlinkHref =
   (editor: Editor, modelElementName: string, logger: Logger): DowncastConversionHelperFunction =>

--- a/packages/ckeditor5-coremedia-images/src/converters.ts
+++ b/packages/ckeditor5-coremedia-images/src/converters.ts
@@ -78,8 +78,7 @@ export const preventUpcastImageSrc =
 export const editingDowncastXlinkHref =
   (editor: Editor, modelElementName: string): DowncastConversionHelperFunction =>
   (dispatcher: DowncastDispatcher) => {
-    dispatcher.on(`attribute:xlink-href:${modelElementName}`, (eventInfo: EventInfo, data): void => {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    dispatcher.on(`attribute:xlink-href:${modelElementName}`, (eventInfo: EventInfo, data: DowncastEventData): void => {
       if (data.attributeNewValue === "") {
         // There was no xlink-href set for this image, therefore we can skip applying
         // the loading spinner and resolving the image src

--- a/packages/ckeditor5-coremedia-images/src/converters.ts
+++ b/packages/ckeditor5-coremedia-images/src/converters.ts
@@ -79,7 +79,7 @@ export const editingDowncastXlinkHref =
   (editor: Editor, modelElementName: string): DowncastConversionHelperFunction =>
   (dispatcher: DowncastDispatcher) => {
     dispatcher.on(`attribute:xlink-href:${modelElementName}`, (eventInfo: EventInfo, data: DowncastEventData): void => {
-      if (data.attributeNewValue === "") {
+      if (!data.attributeNewValue) {
         // There was no xlink-href set for this image, therefore we can skip applying
         // the loading spinner and resolving the image src
         return;


### PR DESCRIPTION
We cannot assume that processed images have a valid uriPath as xlink-href. In case the attribute is not a valid uriPath, we must exit early, to not run into an error which would break the editor.

We Therefore must check if the attribute is set on downcast, right before creating the spinner marker. If the xlink-href is empty (empty string), simply show a broken image. (Skip the rest of the computation)

Later, the xlink-href attribute is converted to the resulting uriPath. If this fails, do not break the editor, but instead just return early. In this case, the spinner will stay.