### PR TITLE
VisibleView null check added

### DIFF
--- a/packages/ckeditor5-coremedia-link/src/contentlink/ContentLinks.ts
+++ b/packages/ckeditor5-coremedia-link/src/contentlink/ContentLinks.ts
@@ -78,7 +78,7 @@ export default class ContentLinks extends Plugin {
 
     const contextualBalloon: ContextualBalloon = editor.plugins.get(ContextualBalloon);
     contextualBalloon.on("change:visibleView", (evt, name, visibleView) => {
-      if (visibleView !== null && visibleView === linkUI.actionsView && !this.#initialized) {
+      if (visibleView && visibleView === linkUI.actionsView && !this.#initialized) {
         this.onVisibleViewChanged(linkUI);
         this.#initialized = true;
       }

--- a/packages/ckeditor5-coremedia-link/src/contentlink/ContentLinks.ts
+++ b/packages/ckeditor5-coremedia-link/src/contentlink/ContentLinks.ts
@@ -78,7 +78,7 @@ export default class ContentLinks extends Plugin {
 
     const contextualBalloon: ContextualBalloon = editor.plugins.get(ContextualBalloon);
     contextualBalloon.on("change:visibleView", (evt, name, visibleView) => {
-      if (visibleView === linkUI.actionsView && !this.#initialized) {
+      if (visibleView !== null && visibleView === linkUI.actionsView && !this.#initialized) {
         this.onVisibleViewChanged(linkUI);
         this.#initialized = true;
       }

--- a/packages/ckeditor5-coremedia-link/src/contentlink/ui/ContentLinkActionsViewExtension.ts
+++ b/packages/ckeditor5-coremedia-link/src/contentlink/ui/ContentLinkActionsViewExtension.ts
@@ -121,7 +121,7 @@ class ContentLinkActionsViewExtension extends Plugin {
     contentLinkView.on("change:contentName", () => {
       if (!this.editor.isReadOnly) {
         const contextualBalloon: ContextualBalloon = this.editor.plugins.get(ContextualBalloon);
-        if (contextualBalloon.visibleView !== null && contextualBalloon.visibleView === linkUI.actionsView) {
+        if (contextualBalloon.visibleView && contextualBalloon.visibleView === linkUI.actionsView) {
           contextualBalloon.updatePosition();
         }
       }

--- a/packages/ckeditor5-coremedia-link/src/contentlink/ui/ContentLinkActionsViewExtension.ts
+++ b/packages/ckeditor5-coremedia-link/src/contentlink/ui/ContentLinkActionsViewExtension.ts
@@ -121,7 +121,7 @@ class ContentLinkActionsViewExtension extends Plugin {
     contentLinkView.on("change:contentName", () => {
       if (!this.editor.isReadOnly) {
         const contextualBalloon: ContextualBalloon = this.editor.plugins.get(ContextualBalloon);
-        if (contextualBalloon.visibleView === linkUI.actionsView) {
+        if (contextualBalloon.visibleView !== null && contextualBalloon.visibleView === linkUI.actionsView) {
           contextualBalloon.updatePosition();
         }
       }

--- a/packages/ckeditor5-coremedia-link/src/contentlink/ui/ContentLinkFormViewExtension.ts
+++ b/packages/ckeditor5-coremedia-link/src/contentlink/ui/ContentLinkFormViewExtension.ts
@@ -58,14 +58,14 @@ class ContentLinkFormViewExtension extends Plugin {
     const linkUI: LinkUI = editor.plugins.get(LinkUI);
     const contextualBalloon: ContextualBalloon = editor.plugins.get(ContextualBalloon);
     contextualBalloon.on("change:visibleView", (evt, name, visibleView) => {
-      if (visibleView === linkUI.formView && !this.#initialized) {
+      if (visibleView !== null && visibleView === linkUI.formView && !this.#initialized) {
         this.initializeFormView(linkUI);
         this.#initialized = true;
       }
     });
 
     contextualBalloon.on("change:visibleView", (evt, name, visibleView) => {
-      if (visibleView === linkUI.formView) {
+      if (visibleView !== null && visibleView === linkUI.formView) {
         this.onFormViewGetsActive(linkUI);
       }
     });
@@ -208,7 +208,7 @@ class ContentLinkFormViewExtension extends Plugin {
     contentLinkView.on("change:contentName", () => {
       if (!this.editor.isReadOnly) {
         const contextualBalloon: ContextualBalloon = this.editor.plugins.get(ContextualBalloon);
-        if (contextualBalloon.visibleView === linkUI.formView) {
+        if (contextualBalloon.visibleView !== null && contextualBalloon.visibleView === linkUI.formView) {
           contextualBalloon.updatePosition();
         }
       }

--- a/packages/ckeditor5-coremedia-link/src/contentlink/ui/ContentLinkFormViewExtension.ts
+++ b/packages/ckeditor5-coremedia-link/src/contentlink/ui/ContentLinkFormViewExtension.ts
@@ -58,14 +58,14 @@ class ContentLinkFormViewExtension extends Plugin {
     const linkUI: LinkUI = editor.plugins.get(LinkUI);
     const contextualBalloon: ContextualBalloon = editor.plugins.get(ContextualBalloon);
     contextualBalloon.on("change:visibleView", (evt, name, visibleView) => {
-      if (visibleView !== null && visibleView === linkUI.formView && !this.#initialized) {
+      if (visibleView && visibleView === linkUI.formView && !this.#initialized) {
         this.initializeFormView(linkUI);
         this.#initialized = true;
       }
     });
 
     contextualBalloon.on("change:visibleView", (evt, name, visibleView) => {
-      if (visibleView !== null && visibleView === linkUI.formView) {
+      if (visibleView && visibleView === linkUI.formView) {
         this.onFormViewGetsActive(linkUI);
       }
     });
@@ -208,7 +208,7 @@ class ContentLinkFormViewExtension extends Plugin {
     contentLinkView.on("change:contentName", () => {
       if (!this.editor.isReadOnly) {
         const contextualBalloon: ContextualBalloon = this.editor.plugins.get(ContextualBalloon);
-        if (contextualBalloon.visibleView !== null && contextualBalloon.visibleView === linkUI.formView) {
+        if (contextualBalloon.visibleView && contextualBalloon.visibleView === linkUI.formView) {
           contextualBalloon.updatePosition();
         }
       }

--- a/packages/ckeditor5-coremedia-link/src/linktarget/LinkTargetActionsViewExtension.ts
+++ b/packages/ckeditor5-coremedia-link/src/linktarget/LinkTargetActionsViewExtension.ts
@@ -42,7 +42,7 @@ class LinkTargetActionsViewExtension extends Plugin {
     const linkUI: LinkUI = editor.plugins.get(LinkUI);
     const contextualBalloon: ContextualBalloon = editor.plugins.get(ContextualBalloon);
     contextualBalloon.on("change:visibleView", (evt, name, visibleView) => {
-      if (visibleView === linkUI.actionsView && !this.#initialized) {
+      if (visibleView !== null && visibleView === linkUI.actionsView && !this.#initialized) {
         this.#extendView(linkUI);
         this.#initialized = true;
       }

--- a/packages/ckeditor5-coremedia-link/src/linktarget/LinkTargetActionsViewExtension.ts
+++ b/packages/ckeditor5-coremedia-link/src/linktarget/LinkTargetActionsViewExtension.ts
@@ -42,7 +42,7 @@ class LinkTargetActionsViewExtension extends Plugin {
     const linkUI: LinkUI = editor.plugins.get(LinkUI);
     const contextualBalloon: ContextualBalloon = editor.plugins.get(ContextualBalloon);
     contextualBalloon.on("change:visibleView", (evt, name, visibleView) => {
-      if (visibleView !== null && visibleView === linkUI.actionsView && !this.#initialized) {
+      if (visibleView && visibleView === linkUI.actionsView && !this.#initialized) {
         this.#extendView(linkUI);
         this.#initialized = true;
       }


### PR DESCRIPTION
linkUI.formView or linkUI.actionsView can be null here, if e.g. the imageBalloon was opened and closed here. Then, the linkUI view would be null and the visibleView is null as well when closing a balloon, leading to an error.