### PR TITLE
docs(link): Fixes Documentation Issues

### DIFF
--- a/packages/ckeditor5-coremedia-richtext/src/index-doc.ts
+++ b/packages/ckeditor5-coremedia-richtext/src/index-doc.ts
@@ -9,6 +9,7 @@
  */
 
 export * as compatibility from "./compatibility/index-doc";
+export * as integrations from "./integrations/index-doc";
 export * as rules from "./rules/index-doc";
 export * as sanitation from "./sanitation/index-doc";
 

--- a/packages/ckeditor5-coremedia-richtext/src/integrations/index-doc.ts
+++ b/packages/ckeditor5-coremedia-richtext/src/integrations/index-doc.ts
@@ -1,0 +1,8 @@
+/**
+ * Integrations of CoreMedia Rich Text 1.0 features into other features.
+ *
+ * @packageDocumentation
+ * @category Virtual
+ */
+
+export * from "./LinkIntegration";

--- a/packages/ckeditor5-link-common/README.md
+++ b/packages/ckeditor5-link-common/README.md
@@ -1,4 +1,8 @@
 # CKEditor 5 Link Common
 
+[![API Documentation][badge:docs:api]][api:ckeditor-plugins]
+
 This package contains some assistive tooling around `@ckeditor/ckeditor5-link`
 API to ease integration with the link feature.
+
+[api:ckeditor-plugins]: <https://coremedia.github.io/ckeditor-plugins/docs/api/modules/ckeditor5_coremedia_link.link.html> "Namespace link"

--- a/packages/ckeditor5-link-common/src/index-doc.ts
+++ b/packages/ckeditor5-link-common/src/index-doc.ts
@@ -2,32 +2,52 @@
  * # CKEditor 5 Link Feature Extension Point
  *
  * CKEditor 5 does not provide extension points for adding for sophisticated
- * behaviors to links. In here you will find the extension points required by the
- * CKEditor plugins provided here.
+ * behaviors to links.
+ * Here you will find the extension points required by the CKEditor plugins
+ * provided here.
  *
- * ## Additional Link Attributes
+ * ## LinkAttributes
  *
- * **Challenge:** If you provide additional attributes for links (i.e., texts with
- * `linkHref` model attribute), you may want to automatically remove them, when the
- * attribute got removed by the `UnlinkCommand` for example.
+ * The central API when it comes to deal with attributes in relation to
+ * links is the plugin `LinkAttributes`.
  *
- * Yet, you want only one Undo-step for the removal of both attributes, i.e.,
- * undoing one `unlink` action has to restore both attributes, your custom one and
- * `linkHref`.
+ * In short, you register a custom attribute by its view representation
+ * (data and editing view) along with a representation in the model.
+ * The plugin will register corresponding up- and downcast rules and
+ * incorporates best practices regarding the priorities and model attribute
+ * prefixes, to smoothly integrate with the CKEditor 5 link feature.
+ *
+ * Unless CKEditor 5 provides its own solution for registering such
+ * attributes, it is recommended using this plugin for any additional
+ * attribute bound to links.
+ *
+ * For details, consult the corresponding class level documentation.
+ *
+ * ## LinkCleanup
+ *
+ * **Challenge:** If you provide additional attributes for links (i.e., texts
+ * with `linkHref` model attribute), you may want to automatically remove them,
+ * when the attribute got removed by the `UnlinkCommand`, for example.
+ *
+ * Yet you want only one Undo-step for the removal of both attributes; i.e.,
+ * undoing one `unlink` action has to restore both attributes, your custom one
+ * and `linkHref`.
  *
  * **Solution:** The solution is registering a post-fixer at CKEditor's document
  * instance. And to ease this approach, you may use the `LinkCleanup` plugin. You
- * can register any attribute, which must not exist without corresponding
+ * can register any attribute, which must not exist without the corresponding
  * `linkHref` attribute:
  *
  * ```typescript
  * getLinkCleanup(editor)?.registerDependentAttribute("linkCustom");
  * ```
  *
- * This requires to add `LinkCleanup` as required dependency to your plugin.
+ * `LinkCleanup` is automatically invoked from `LinkAttributes`. Unless you need
+ * more fine-grained control in contrast to that one provided by
+ * `LinkAttributes` (such as different downcasting to data view and to editing
+ * view), `LinkCleanup` is not required to be used directly.
  *
- * @packageDocumentation
- * @category Virtual
+ * @module ckeditor5-link-common
  */
 
 export * as Constants from "./Constants";


### PR DESCRIPTION
Repairs appearance in GitHub pages regarding rendered API documentation.