### PR TITLE
Content-Link: Fixes Mixed Keyboard/Mouse Access to Opening Content Links

### DIFF
--- a/app/src/inputExampleContents.ts
+++ b/app/src/inputExampleContents.ts
@@ -9,12 +9,12 @@ const INPUT_EXAMPLE_CONTENT_DIV_CLASS = "inputExampleContentDiv";
 const initInputExampleContent = (editor: ClassicEditor) => {
   const mockContentPlugin = editor.plugins.get(MockContentPlugin);
   const mockInputExamplePlugin = editor.plugins.get(MockInputExamplePlugin);
-  // Just ensure, that the default content provided by MockContentPlugin
+  // Just ensure that the default content provided by MockContentPlugin
   // still fulfills our expectations.
   const requireExplicitContent = mockContentPlugin.requireExplicitContent;
 
-  // Add some content of not insertable type. (By default only contents of type 'document'
-  // are considered insertable.
+  // Add some content of not insertable type. By default, only contents of type
+  // 'document' are considered insertable.
   mockContentPlugin.addContents({
     id: 40,
     type: "notinsertable",

--- a/app/src/inputExampleContents.ts
+++ b/app/src/inputExampleContents.ts
@@ -36,6 +36,12 @@ const initInputExampleContent = (editor: ClassicEditor) => {
       items: [32],
     },
     {
+      label: "Short Name",
+      tooltip: "Document with short name (1-unicode char)",
+      classes: ["linkable", "type-document"],
+      items: [114],
+    },
+    {
       label: "Document (edit)",
       tooltip: "Document which is actively edited",
       classes: ["linkable", "type-document"],

--- a/packages/ckeditor5-coremedia-content/package.json
+++ b/packages/ckeditor5-coremedia-content/package.json
@@ -21,10 +21,8 @@
     "@coremedia-internal/ckeditor5-babel-config": "^1.0.0",
     "@coremedia-internal/ckeditor5-jest-test-helpers": "^1.0.0",
     "@ckeditor/ckeditor5-core": "^36.0.1",
-    "@ckeditor/ckeditor5-ui": "^36.0.1",
     "@coremedia/service-agent": "^1.1.5",
     "@types/ckeditor__ckeditor5-core": "^33.0.3",
-    "@types/ckeditor__ckeditor5-ui": "^32.0.2",
     "@types/jest": "^28.1.8",
     "jest": "^28.1.3",
     "jest-config": "^28.1.3",
@@ -37,7 +35,6 @@
   },
   "peerDependencies": {
     "@ckeditor/ckeditor5-core": "^36.0.1",
-    "@ckeditor/ckeditor5-ui": "^36.0.1",
     "@coremedia/service-agent": "^1.1.5"
   },
   "scripts": {

--- a/packages/ckeditor5-coremedia-content/src/OpenInTab.ts
+++ b/packages/ckeditor5-coremedia-content/src/OpenInTab.ts
@@ -1,0 +1,67 @@
+import LoggerProvider from "@coremedia/ckeditor5-logging/logging/LoggerProvider";
+import { serviceAgent } from "@coremedia/service-agent";
+import { createWorkAreaServiceDescriptor } from "@coremedia/ckeditor5-coremedia-studio-integration/content/WorkAreaServiceDescriptor";
+
+const logger = LoggerProvider.getLogger("OpenInTab");
+
+/**
+ * Retrieve the workarea service.
+ */
+const fetchWorkAreaService = () => serviceAgent.fetchService(createWorkAreaServiceDescriptor());
+
+/**
+ * Result provided by `WorkAreaService.openEntitiesInTabs`.
+ */
+export interface OpenEntitiesInTabsResult {
+  accepted: string[];
+  rejected: string[];
+}
+
+/**
+ * Empty response from `WorkAreaService.openEntitiesInTabs`.
+ */
+export const emptyOpenEntitiesInTabsResult: OpenEntitiesInTabsResult = {
+  accepted: [],
+  rejected: [],
+};
+
+/**
+ * Queries, if all provided URI paths can be opened in tab.
+ *
+ * @param uriPaths - URI paths to validate
+ */
+export const canAllBeOpenedInTab = async (...uriPaths: string[]): Promise<boolean> => {
+  if (uriPaths.length === 0) {
+    return false;
+  }
+
+  return fetchWorkAreaService().then(
+    (workAreaService): Promise<boolean> =>
+      workAreaService.canBeOpenedInTab(uriPaths).catch((error): boolean => {
+        logger.debug(`Failed to query "canBeOpenedInTab" for ${uriPaths}. Default to false.`, error);
+        return false;
+      })
+  );
+};
+
+/**
+ * Queries, if the provided URI path can be opened in tab.
+ *
+ * @param uriPath - URI path to validate
+ */
+export const canBeOpenedInTab = (uriPath: string): Promise<boolean> => canAllBeOpenedInTab(uriPath);
+
+/**
+ * Open the given entities in tabs.
+ *
+ * @param uriPaths - URI paths to open
+ */
+export const openEntitiesInTabs = async (...uriPaths: string[]): Promise<OpenEntitiesInTabsResult> => {
+  logger.debug(`Triggered to open in tab (${uriPaths.length}): ${uriPaths}`);
+  if (uriPaths.length === 0) {
+    return emptyOpenEntitiesInTabsResult;
+  }
+  return fetchWorkAreaService().then(
+    (workAreaService): Promise<OpenEntitiesInTabsResult> => workAreaService.openEntitiesInTabs(uriPaths)
+  );
+};

--- a/packages/ckeditor5-coremedia-content/src/commands/OpenInTabCommand.ts
+++ b/packages/ckeditor5-coremedia-content/src/commands/OpenInTabCommand.ts
@@ -10,11 +10,17 @@ import { canBeOpenedInTab, openEntitiesInTabs, OpenEntitiesInTabsResult } from "
 
 // noinspection JSConstantReassignment
 /**
- * An abstract command for opening contents in a tab.
+ * A command for opening contents in a tab.
  *
  * By default, has no value and is always enabled. Provides method
  * `refreshValueAndEnabledState` to update value and enabled state
- * based on the given value.
+ * based on the given value. This method are meant to be invoked
+ * by extending commands.
+ *
+ * The command itself, without further adaptations, may be used to
+ * directly open commands via `execute()` method. As the value is
+ * not updated by default, it is expected that URI paths to open are
+ * given explicitly then.
  *
  * @augments module:core/command~Command
  */

--- a/packages/ckeditor5-coremedia-content/src/index-doc.ts
+++ b/packages/ckeditor5-coremedia-content/src/index-doc.ts
@@ -5,3 +5,4 @@
  */
 
 export * as ui from "./commands/index-doc";
+export * from "./OpenInTab";

--- a/packages/ckeditor5-coremedia-images/src/ContentImageEditingPlugin.ts
+++ b/packages/ckeditor5-coremedia-images/src/ContentImageEditingPlugin.ts
@@ -10,9 +10,9 @@ import {
   reportInitEnd,
   reportInitStart,
 } from "@coremedia/ckeditor5-core-common/Plugins";
-import { OpenInTabCommand } from "@coremedia/ckeditor5-coremedia-content/commands/OpenInTabCommand";
 import Logger from "@coremedia/ckeditor5-logging/logging/Logger";
 import LoggerProvider from "@coremedia/ckeditor5-logging/logging/LoggerProvider";
+import { registerOpenImageInTabCommand } from "./contentImageOpenInTab/OpenImageInTabCommand";
 
 /**
  * Plugin to support images from CoreMedia RichText.
@@ -37,7 +37,7 @@ export default class ContentImageEditingPlugin extends Plugin {
   init(): void {
     const editor = this.editor;
     const initInformation = reportInitStart(this);
-    editor.commands.add("openImageInTab", new OpenInTabCommand(editor, "xlink-href", "imageInline"));
+    registerOpenImageInTabCommand(editor);
     reportInitEnd(initInformation);
   }
 

--- a/packages/ckeditor5-coremedia-images/src/contentImageOpenInTab/ContentImageOpenInTabUI.ts
+++ b/packages/ckeditor5-coremedia-images/src/contentImageOpenInTab/ContentImageOpenInTabUI.ts
@@ -7,6 +7,7 @@ import "../lang/contentImageOpenInTab";
 import { EditorWithUI } from "@ckeditor/ckeditor5-core/src/editor/editorwithui";
 import { reportInitEnd, reportInitStart } from "@coremedia/ckeditor5-core-common/Plugins";
 import ContentImageEditingPlugin from "../ContentImageEditingPlugin";
+import { executeOpenImageInTabCommand, requireOpenImageInTabCommand } from "./OpenImageInTabCommand";
 
 /**
  * Plugin that registers a 'contentImageOpenInTab' button in
@@ -32,20 +33,13 @@ export default class ContentImageOpenInTabUI extends Plugin {
     const { ui } = requireEditorWithUI(this.editor);
     const t = editor.t;
 
-    const openInTabCommand = editor.commands.get("openImageInTab");
-    if (!openInTabCommand) {
-      throw new Error('The command "openImageInTab" is required.');
-    }
-
     const OPEN_IN_TAB_KEYSTROKE = "Ctrl+Shift+O";
 
     editor.keystrokes.set(OPEN_IN_TAB_KEYSTROKE, (keyEvtData, cancel) => {
       // Prevent focusing the search bar in FF, Chrome and Edge. See https://github.com/ckeditor/ckeditor5/issues/4811.
       cancel();
 
-      if (openInTabCommand.isEnabled) {
-        openInTabCommand.execute();
-      }
+      executeOpenImageInTabCommand(editor);
     });
 
     ui.componentFactory.add("contentImageOpenInTab", (locale) => {
@@ -59,10 +53,10 @@ export default class ContentImageOpenInTabUI extends Plugin {
         tooltip: true,
       });
 
-      button.bind("isEnabled").to(openInTabCommand, "isEnabled");
+      button.bind("isEnabled").to(requireOpenImageInTabCommand(editor), "isEnabled");
 
       this.listenTo(button, "execute", () => {
-        openInTabCommand.execute();
+        executeOpenImageInTabCommand(editor);
       });
       return button;
     });

--- a/packages/ckeditor5-coremedia-images/src/contentImageOpenInTab/OpenImageInTabCommand.ts
+++ b/packages/ckeditor5-coremedia-images/src/contentImageOpenInTab/OpenImageInTabCommand.ts
@@ -1,0 +1,75 @@
+import { OpenInTabCommand } from "@coremedia/ckeditor5-coremedia-content/commands/OpenInTabCommand";
+import Editor from "@ckeditor/ckeditor5-core/src/editor/editor";
+import ImageUtils from "@ckeditor/ckeditor5-image/src/imageutils";
+import LoggerProvider from "@coremedia/ckeditor5-logging/logging/LoggerProvider";
+
+/**
+ * Default command name used to register at editor instance.
+ */
+export const openImageInTabCommandName = "openImageInTab";
+
+/**
+ * A command to open either a given URI path (on `execute`) or the URI path
+ * available in the current model state.
+ */
+export class OpenImageInTabCommand extends OpenInTabCommand {
+  static #logger = LoggerProvider.getLogger("OpenImageInTabCommand");
+
+  override refresh() {
+    const logger = OpenImageInTabCommand.#logger;
+    const { editor } = this;
+    const imageUtils = editor.plugins.get(ImageUtils);
+    const { model } = editor;
+    const { document } = model;
+    const { selection } = document;
+    const element = imageUtils.getClosestSelectedImageElement(selection);
+    if (element) {
+      const xlinkHrefValue = element.getAttribute("xlink-href");
+      this.refreshValueAndEnabledState(xlinkHrefValue);
+      logger.debug(`Enabled state updated according to xlink-href value of "${xlinkHrefValue}": ${this.isEnabled}`);
+    } else {
+      // noinspection JSConstantReassignment
+      this.isEnabled = false;
+      logger.debug("Disable command, as current selection does not represent an image.");
+    }
+  }
+}
+
+/**
+ * Registers the `OpenImageInTabCommand`.
+ *
+ * @param editor - editor instance to register command at
+ * @param name - name of the command
+ */
+export const registerOpenImageInTabCommand = (editor: Editor, name = openImageInTabCommandName) =>
+  editor.commands.add(name, new OpenImageInTabCommand(editor));
+
+/**
+ * Require the command to be available and return it.
+ *
+ * @param editor - editor instance to lookup command at
+ * @param name - name of the command
+ * @throws Error - if the required command is unavailable
+ */
+export const requireOpenImageInTabCommand = (editor: Editor, name = openImageInTabCommandName) => {
+  const command = editor.commands.get(name);
+  if (!command) {
+    throw new Error(`Missing required command ${name}.`);
+  }
+  return command;
+};
+
+/**
+ * Executes `OpenImageInTabCommand`, if available. Optional URI paths may
+ * be provided to override URI paths as possibly evaluated from the model
+ * state.
+ *
+ * @param editor - editor instance to invoke the command for
+ * @param uriPaths - URI path to open explicitly (overrides the model state)
+ * @param name - name of the command
+ */
+export const executeOpenImageInTabCommand = (
+  editor: Editor,
+  uriPaths: string[] = [],
+  name = openImageInTabCommandName
+) => editor.commands.get(name)?.execute(...uriPaths);

--- a/packages/ckeditor5-coremedia-images/src/contentImageOpenInTab/index-doc.ts
+++ b/packages/ckeditor5-coremedia-images/src/contentImageOpenInTab/index-doc.ts
@@ -4,3 +4,4 @@
  * @module ckeditor5-coremedia-images
  */
 export { default as ContentImageOpenInTabUI } from "./ContentImageOpenInTabUI";
+export * from "./OpenImageInTabCommand";

--- a/packages/ckeditor5-coremedia-link/src/contentlink/ContentLinks.ts
+++ b/packages/ckeditor5-coremedia-link/src/contentlink/ContentLinks.ts
@@ -10,7 +10,6 @@ import ContentLinkClipboardPlugin from "./ContentLinkClipboardPlugin";
 import LinkUserActionsPlugin from "./LinkUserActionsPlugin";
 import ContextualBalloon from "@ckeditor/ckeditor5-ui/src/panel/balloon/contextualballoon";
 import { CONTENT_CKE_MODEL_URI_REGEXP } from "@coremedia/ckeditor5-coremedia-studio-integration/content/UriPath";
-import { OpenInTabCommand } from "@coremedia/ckeditor5-coremedia-content/commands/OpenInTabCommand";
 import LinkCommand from "@ckeditor/ckeditor5-link/src/linkcommand";
 import { serviceAgent } from "@coremedia/service-agent";
 import { addMouseEventListenerToHideDialog, removeInitialMouseDownListener } from "./LinkBalloonEventListenerFix";
@@ -21,6 +20,7 @@ import WorkAreaService from "@coremedia/ckeditor5-coremedia-studio-integration/c
 import { closeContextualBalloon } from "./ContentLinkViewUtils";
 import LoggerProvider from "@coremedia/ckeditor5-logging/logging/LoggerProvider";
 import { parseLinkBalloonConfig } from "./LinkBalloonConfig";
+import { registerOpenContentInTabCommand } from "./OpenContentInTabCommand";
 
 /**
  * This plugin allows content objects to be dropped into the link dialog.
@@ -51,7 +51,7 @@ export default class ContentLinks extends Plugin {
 
   /**
    * Removes the focus on the editor and clears the selection.
-   * Can be used to clear all activity on the editor when contextual
+   * Can be used to clear all activity in the editor when contextual
    * balloons are closed manually.
    *
    * @private
@@ -83,6 +83,8 @@ export default class ContentLinks extends Plugin {
         this.#initialized = true;
       }
     });
+
+    registerOpenContentInTabCommand(editor);
   }
 
   onVisibleViewChanged(linkUI: LinkUI): void {
@@ -121,7 +123,5 @@ export default class ContentLinks extends Plugin {
       },
       this
     );
-    // registers the openInTab command for content links, used to open a content when clicking the content link
-    editor.commands.add("openLinkInTab", new OpenInTabCommand(editor, "linkHref"));
   }
 }

--- a/packages/ckeditor5-coremedia-link/src/contentlink/OpenContentInTabCommand.ts
+++ b/packages/ckeditor5-coremedia-link/src/contentlink/OpenContentInTabCommand.ts
@@ -1,0 +1,80 @@
+import { OpenInTabCommand } from "@coremedia/ckeditor5-coremedia-content/commands/OpenInTabCommand";
+import first from "@ckeditor/ckeditor5-utils/src/first";
+import type Schema from "@ckeditor/ckeditor5-engine/src/model/schema";
+import type ModelElement from "@ckeditor/ckeditor5-engine/src/model/element";
+import Editor from "@ckeditor/ckeditor5-core/src/editor/editor";
+
+/**
+ * Default command name used to register at editor instance.
+ */
+export const openContentInTabCommandName = "openContentInTab";
+
+/**
+ * A command to open either a given URI path (on `execute`) or the URI path
+ * available in the current model state.
+ */
+export class OpenContentInTabCommand extends OpenInTabCommand {
+  override refresh() {
+    const { editor } = this;
+    const { model } = editor;
+    const { schema, document } = model;
+    const { selection } = document;
+    const selectedElement = selection.getSelectedElement() ?? first(selection.getSelectedBlocks());
+
+    // See `LinkCommand.refresh()` for similar implementation.
+    if (isLinkableElement(selectedElement, schema)) {
+      this.refreshValue(selectedElement.getAttribute("linkHref"));
+    } else {
+      this.refreshValue(selection.getAttribute("linkHref"));
+    }
+
+    // Defaults to set enabled state to `true`.
+    super.refresh();
+
+    // DevNote: Enabled State Always `true`
+    // We could consider depending the enabled state depending on if the
+    // model provides a URI path **and** if it can be opened. This would
+    // be helpful if the enabled state is represented in the UI in some way.
+    // In general, there is no harm to "try to open" contents. If any of them
+    // cannot be opened, they just won't open.
+  }
+}
+
+/**
+ * Registers the `OpenContentInTabCommand`.
+ *
+ * @param editor - editor instance to register command at
+ * @param name - name of the command
+ */
+export const registerOpenContentInTabCommand = (editor: Editor, name = openContentInTabCommandName) =>
+  editor.commands.add(name, new OpenContentInTabCommand(editor));
+
+/**
+ * Executes `OpenContentInTabCommand`, if available. Optional URI paths may
+ * be provided to override URI paths as possibly evaluated from the model
+ * state.
+ *
+ * @param editor - editor instance to invoke the command for
+ * @param uriPaths - URI path to open explicitly (overrides the model state)
+ * @param name - name of the command
+ */
+export const executeOpenContentInTabCommand = (
+  editor: Editor,
+  uriPaths: string[] = [],
+  name = openContentInTabCommandName
+) => editor.commands.get(name)?.execute(...uriPaths);
+
+/**
+ * Checks if the given element represents a linkable element. Copy of
+ * the corresponding check in CKEditor 5 Link-Feature.
+ *
+ * @param element - current model element
+ * @param schema - model schema
+ */
+const isLinkableElement = (element: ModelElement | null, schema: Schema): element is ModelElement => {
+  if (!element) {
+    return false;
+  }
+
+  return schema.checkAttribute(element.name, "linkHref");
+};

--- a/packages/ckeditor5-coremedia-link/src/contentlink/index-doc.ts
+++ b/packages/ckeditor5-coremedia-link/src/contentlink/index-doc.ts
@@ -22,3 +22,5 @@ export * as ContentLinkViewUtils from "./ContentLinkViewUtils";
 
 export * from "./LinkBalloonConfig";
 export { default as LinkBalloonConfig } from "./LinkBalloonConfig";
+
+export * from "./OpenContentInTabCommand";

--- a/packages/ckeditor5-coremedia-link/src/contentlink/ui/ContentLinkActionsViewExtension.ts
+++ b/packages/ckeditor5-coremedia-link/src/contentlink/ui/ContentLinkActionsViewExtension.ts
@@ -14,6 +14,7 @@ import { ifCommand } from "@coremedia/ckeditor5-core-common/Commands";
 import LoggerProvider from "@coremedia/ckeditor5-logging/logging/LoggerProvider";
 import { hasContentUriPath } from "./ViewExtensions";
 import { showContentLinkField } from "../ContentLinkViewUtils";
+import { executeOpenContentInTabCommand } from "../OpenContentInTabCommand";
 
 /**
  * Extends the action view for Content link display. This includes:
@@ -95,6 +96,7 @@ class ContentLinkActionsViewExtension extends Plugin {
   }
 
   #extendView(linkUI: LinkUI): void {
+    const logger = ContentLinkActionsViewExtension.#logger;
     const { formView } = linkUI;
     const actionsView: LinkActionsView = linkUI.actionsView;
     const contentLinkView = new ContentLinkView(this.editor, {
@@ -104,17 +106,18 @@ class ContentLinkActionsViewExtension extends Plugin {
       renderAsTextLink: true,
     });
     if (!hasContentUriPath(linkUI.actionsView)) {
-      ContentLinkActionsViewExtension.#logger.warn(
-        "ActionsView does not have a property contentUriPath. Is it already bound?",
-        linkUI.actionsView
-      );
+      logger.warn("ActionsView does not have a property contentUriPath. Is it already bound?", {
+        actionsView,
+      });
       return;
     }
     contentLinkView.bind("uriPath").to(linkUI.actionsView, "contentUriPath");
 
     contentLinkView.on("contentClick", () => {
-      if (contentLinkView.uriPath) {
-        this.editor.commands.get("openLinkInTab")?.execute();
+      const { uriPath } = contentLinkView;
+      if (uriPath) {
+        logger.debug(`Executing OpenContentInTabCommand for: ${uriPath}.`);
+        executeOpenContentInTabCommand(this.editor, [uriPath]);
       }
     });
 
@@ -164,7 +167,7 @@ class ContentLinkActionsViewExtension extends Plugin {
   }
 
   /**
-   * Add classes to the actions view which enables to distinguish if the extension is active.
+   * Add classes to the actions view that enables to distinguish if the extension is active.
    *
    * @param actionsView - the rendered actionsView of the linkUI
    * @private

--- a/packages/ckeditor5-coremedia-link/src/contentlink/ui/ContentLinkViewFactory.ts
+++ b/packages/ckeditor5-coremedia-link/src/contentlink/ui/ContentLinkViewFactory.ts
@@ -3,6 +3,8 @@ import "../../../theme/contentlinkview.css";
 import LinkUI from "@ckeditor/ckeditor5-link/src/linkui";
 import ContentLinkView from "./ContentLinkView";
 import Editor from "@ckeditor/ckeditor5-core/src/editor/editor";
+import LoggerProvider from "@coremedia/ckeditor5-logging/logging/LoggerProvider";
+import { executeOpenContentInTabCommand } from "../OpenContentInTabCommand";
 
 /**
  * Creates an ContentLinkView that renders content links in the link form-view.
@@ -14,6 +16,8 @@ import Editor from "@ckeditor/ckeditor5-core/src/editor/editor";
  * @param editor - the editor
  */
 const createContentLinkView = (linkUI: LinkUI, editor: Editor): LabeledFieldView => {
+  const logger = LoggerProvider.getLogger("ContentLinkView");
+
   const { t } = editor.locale;
   const { formView } = linkUI;
   const contentLinkView: LabeledFieldView = new LabeledFieldView(
@@ -31,17 +35,24 @@ const createContentLinkView = (linkUI: LinkUI, editor: Editor): LabeledFieldView
     class: "cm-ck-content-link-view-wrapper",
   });
 
+  const { fieldView } = contentLinkView;
+
   // Propagate URI-Path from formView (see FormViewExtension) to ContentLinkView
   // @ts-expect-error TODO Fix According to Typings
-  contentLinkView.fieldView.bind("uriPath").to(formView, "contentUriPath");
-  // Propagate Content Name from ContentLinkView to FormView, as we require to
-  // know the name in some link insertion scenarios.
+  fieldView.bind("uriPath").to(formView, "contentUriPath");
+  // Propagate Content Name from ContentLinkView to FormView, as we require
+  // knowing the name in some link insertion scenarios.
   formView.bind("contentName").to(contentLinkView.fieldView);
-  contentLinkView.fieldView.on("contentClick", () => {
-    linkUI.editor.commands.get("openLinkInTab")?.execute();
+  fieldView.on("contentClick", () => {
+    // @ts-expect-error - Fix typings.
+    const { uriPath } = fieldView;
+    if (typeof uriPath === "string") {
+      logger.debug(`Executing OpenContentInTabCommand for: ${uriPath}.`);
+      executeOpenContentInTabCommand(editor, [uriPath]);
+    }
   });
 
-  contentLinkView.fieldView.on("executeCancel", () => {
+  fieldView.on("executeCancel", () => {
     formView.set({
       contentUriPath: undefined,
     });

--- a/packages/ckeditor5-coremedia-studio-integration-mock/src/content/MockWorkAreaService.ts
+++ b/packages/ckeditor5-coremedia-studio-integration-mock/src/content/MockWorkAreaService.ts
@@ -54,13 +54,8 @@ class MockWorkAreaService implements WorkAreaService {
       .map((uri) => mockContentPlugin.getContent(uri))
       .every((mockContent: MockContent): boolean => {
         const allReadable = mockContent.readable.every((isReadable) => isReadable);
-        if (!mockContent.embeddable) {
-          MockWorkAreaService.#LOGGER.debug(`Content is not embeddable and readable is ${allReadable}`);
-          return allReadable;
-        }
-        const dataIsSet = mockContent.blob.every((blobData: BlobType) => blobData?.value);
-        MockWorkAreaService.#LOGGER.debug(`Content is embeddable and readable is ${allReadable}`);
-        return allReadable && dataIsSet;
+        MockWorkAreaService.#LOGGER.debug(`Contents ${entityUris} are readable: ${allReadable}`);
+        return allReadable;
       });
   }
 

--- a/packages/ckeditor5-coremedia-studio-integration-mock/src/content/MockWorkAreaService.ts
+++ b/packages/ckeditor5-coremedia-studio-integration-mock/src/content/MockWorkAreaService.ts
@@ -6,9 +6,10 @@ import WorkAreaService from "@coremedia/ckeditor5-coremedia-studio-integration/c
 import { Editor } from "@ckeditor/ckeditor5-core";
 import MockContentPlugin from "./MockContentPlugin";
 import MockContent from "./MockContent";
-import { BlobType } from "./MutableProperties";
 import LoggerProvider from "@coremedia/ckeditor5-logging/logging/LoggerProvider";
 import { Observable, Subject } from "rxjs";
+
+const isString = (value: unknown): value is string => typeof value === "string";
 
 class MockWorkAreaService implements WorkAreaService {
   static #LOGGER = LoggerProvider.getLogger("WorkAreaService");
@@ -26,8 +27,10 @@ class MockWorkAreaService implements WorkAreaService {
     this.#activeEntitySubject = new Subject<unknown>();
   }
 
-  async openEntitiesInTabs(entities: unknown[]): Promise<unknown> {
-    entities.forEach((entity: unknown): void => {
+  async openEntitiesInTabs(entities: unknown[]): Promise<{ accepted: string[]; rejected: string[] }> {
+    const accepted: string[] = [];
+    entities.filter(isString).forEach((entity: string): void => {
+      accepted.push(entity);
       const node: Element = document.createElement("DIV");
       node.classList.add("notification");
       const textnode: Text = document.createTextNode(`Open Content ${entity} in Studio Tab`);
@@ -40,14 +43,14 @@ class MockWorkAreaService implements WorkAreaService {
     });
 
     this.lastOpenedEntities = entities;
-    return { success: true };
+    return { accepted, rejected: [] };
   }
 
   getLastOpenedEntities(): unknown[] {
     return this.lastOpenedEntities;
   }
 
-  async canBeOpenedInTab(entityUris: unknown[]): Promise<unknown> {
+  async canBeOpenedInTab(entityUris: unknown[]): Promise<boolean> {
     const mockContentPlugin = this.#editor.plugins.get(MockContentPlugin.pluginName) as MockContentPlugin;
     const uris = entityUris as string[];
     return uris

--- a/packages/ckeditor5-coremedia-studio-integration-mock/src/content/PredefinedMockContents.ts
+++ b/packages/ckeditor5-coremedia-studio-integration-mock/src/content/PredefinedMockContents.ts
@@ -81,6 +81,12 @@ const DOCUMENT_MOCKS: PredefinedMockContentConfig[] = [
     editing: [true, false],
     readable: [true, true, true, false, false, false],
   },
+  {
+    id: 114,
+    comment: "Single letter (unicode symbol) name.",
+    name: "\u{1F54A}",
+    editing: [true, false],
+  },
 ];
 const NAME_CHALLENGE_MOCKS: PredefinedMockContentConfig[] = [
   {

--- a/packages/ckeditor5-coremedia-studio-integration/src/content/studioservices/WorkAreaService.ts
+++ b/packages/ckeditor5-coremedia-studio-integration/src/content/studioservices/WorkAreaService.ts
@@ -18,7 +18,11 @@ interface WorkAreaService {
    *
    * @returns the promise indicating success or failure.
    */
-  openEntitiesInTabs(entities: unknown[], background?: boolean, options?: unknown): Promise<unknown>;
+  openEntitiesInTabs(
+    entities: unknown[],
+    background?: boolean,
+    options?: unknown
+  ): Promise<{ accepted: string[]; rejected: string[] }>;
 
   /**
    * Determines whether entities given by their REST URIs can be opened in a tab.
@@ -26,7 +30,7 @@ interface WorkAreaService {
    * @param entityUris - the entities given by their URIs.
    * @returns the promise holding whether the entities can be opened in a tab
    */
-  canBeOpenedInTab(entityUris: unknown[]): Promise<unknown>;
+  canBeOpenedInTab(entityUris: unknown[]): Promise<boolean>;
 
   /**
    * Observes the currently active work area entity.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -537,9 +537,6 @@ importers:
       '@ckeditor/ckeditor5-core':
         specifier: ^36.0.1
         version: 36.0.1
-      '@ckeditor/ckeditor5-ui':
-        specifier: ^36.0.1
-        version: 36.0.1
       '@coremedia-internal/ckeditor5-babel-config':
         specifier: ^1.0.0
         version: link:../ckeditor5-babel-config
@@ -552,9 +549,6 @@ importers:
       '@types/ckeditor__ckeditor5-core':
         specifier: ^33.0.3
         version: 33.0.3
-      '@types/ckeditor__ckeditor5-ui':
-        specifier: ^32.0.2
-        version: 32.0.2
       '@types/jest':
         specifier: ^28.1.8
         version: 28.1.8


### PR DESCRIPTION
> **Replaced:** Due to high conflicts with CKE5 37.x update, rewrote/reapplied in new PR: #148

## The Issue

Given you moved the caret via cursor keys into a link-selection, and you opened the link balloon via Ctrl+K, you may have observed, that opening the link via mouse click failed.

The reason were improper updates of the enabled state of the corresponding command.

## The Fix

The fix mostly consists of refactoring to align detection of related model elements with corresponding features for images and links, as they ship with CKEditor 5. For the central issue, we completely disabled tracking the enabled state for now, as it was for no gain: The UI did not and does not represent a disabled state for unreadable or not existing referenced contents. As long as we don't require this, there is no need of tracking this information via disabled state.

## Suggested Release: Patch

While a lot of API aspects changed around the `OpenInTabCommand`, the API is not considered public by means to be extended or to be used directly. Thus, we consider this a patch release, as it fixes an observable bug.

## Minor Adaptations

### WorkAreaService

Adjusted the forward reference to `WorkAreaService` in CoreMedia CMS according to the provided values, which means, especially, that `openEntitiesInTab` returns a state of successfully opened and not opened (rejected) contents.

### MockWorkAreaService

Fixed `canBeOpenedInTab` to not respect for images, if BLOB data have been set at corresponding image content. This is irrelevant for being able to open a content and causes surprising effects in example-app.

## Remark on Enabled State

Analyzing the example app, you will notice (at least for the image balloon), that the "Open in Content" icon does not update its enabled state when a content gets destroyed or moved to an unreadable location (according to permissions of the corresponding editor).

We do not consider this an issue yet, as balloons are meant to stay open only a short period of time. Next time, when reopening the balloon, the state will have been updated accordingly.
