### PR TITLE
Content-Link: Fixes Mixed Keyboard/Mouse Access to Opening Content Links (Rewrite for CKE5 37.x)

### DIFF
--- a/app/src/inputExampleContents.ts
+++ b/app/src/inputExampleContents.ts
@@ -36,6 +36,12 @@ const initInputExampleContent = (editor: ClassicEditor) => {
       items: [32],
     },
     {
+      label: "Short Name",
+      tooltip: "Document with short name (1-unicode char)",
+      classes: ["linkable", "type-document"],
+      items: [114],
+    },
+    {
       label: "Document (edit)",
       tooltip: "Document which is actively edited",
       classes: ["linkable", "type-document"],

--- a/packages/ckeditor5-coremedia-content/package.json
+++ b/packages/ckeditor5-coremedia-content/package.json
@@ -15,7 +15,6 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@ckeditor/ckeditor5-core": "^37.0.1",
-    "@ckeditor/ckeditor5-ui": "^37.0.1",
     "@coremedia-internal/ckeditor5-jest-test-helpers": "^1.0.0",
     "@coremedia/service-agent": "^1.1.5",
     "@types/jest": "^29.5.0",

--- a/packages/ckeditor5-coremedia-content/src/OpenInTab.ts
+++ b/packages/ckeditor5-coremedia-content/src/OpenInTab.ts
@@ -1,0 +1,67 @@
+import LoggerProvider from "@coremedia/ckeditor5-logging/src/logging/LoggerProvider";
+import { serviceAgent } from "@coremedia/service-agent";
+import { createWorkAreaServiceDescriptor } from "@coremedia/ckeditor5-coremedia-studio-integration/src/content/WorkAreaServiceDescriptor";
+
+const logger = LoggerProvider.getLogger("OpenInTab");
+
+/**
+ * Retrieve the workarea service.
+ */
+const fetchWorkAreaService = () => serviceAgent.fetchService(createWorkAreaServiceDescriptor());
+
+/**
+ * Result provided by `WorkAreaService.openEntitiesInTabs`.
+ */
+export interface OpenEntitiesInTabsResult {
+  accepted: string[];
+  rejected: string[];
+}
+
+/**
+ * Empty response from `WorkAreaService.openEntitiesInTabs`.
+ */
+export const emptyOpenEntitiesInTabsResult: OpenEntitiesInTabsResult = {
+  accepted: [],
+  rejected: [],
+};
+
+/**
+ * Queries, if all provided URI paths can be opened in tab.
+ *
+ * @param uriPaths - URI paths to validate
+ */
+export const canAllBeOpenedInTab = async (...uriPaths: string[]): Promise<boolean> => {
+  if (uriPaths.length === 0) {
+    return false;
+  }
+
+  return fetchWorkAreaService().then(
+    (workAreaService): Promise<boolean> =>
+      workAreaService.canBeOpenedInTab(uriPaths).catch((error): boolean => {
+        logger.debug(`Failed to query "canBeOpenedInTab" for ${uriPaths}. Default to false.`, error);
+        return false;
+      })
+  );
+};
+
+/**
+ * Queries, if the provided URI path can be opened in tab.
+ *
+ * @param uriPath - URI path to validate
+ */
+export const canBeOpenedInTab = (uriPath: string): Promise<boolean> => canAllBeOpenedInTab(uriPath);
+
+/**
+ * Open the given entities in tabs.
+ *
+ * @param uriPaths - URI paths to open
+ */
+export const openEntitiesInTabs = async (...uriPaths: string[]): Promise<OpenEntitiesInTabsResult> => {
+  logger.debug(`Triggered to open in tab (${uriPaths.length}): ${uriPaths}`);
+  if (uriPaths.length === 0) {
+    return emptyOpenEntitiesInTabsResult;
+  }
+  return fetchWorkAreaService().then(
+    (workAreaService): Promise<OpenEntitiesInTabsResult> => workAreaService.openEntitiesInTabs(uriPaths)
+  );
+};

--- a/packages/ckeditor5-coremedia-content/src/commands/OpenInTabCommand.ts
+++ b/packages/ckeditor5-coremedia-content/src/commands/OpenInTabCommand.ts
@@ -1,26 +1,26 @@
 import { Command, Editor } from "@ckeditor/ckeditor5-core";
-import { serviceAgent } from "@coremedia/service-agent";
-import { createWorkAreaServiceDescriptor } from "@coremedia/ckeditor5-coremedia-studio-integration/src/content/WorkAreaServiceDescriptor";
 import {
-  CONTENT_CKE_MODEL_URI_REGEXP,
-  CONTENT_URI_PATH_REGEXP,
+  isModelUriPath,
+  isUriPath,
   requireContentUriPath,
   UriPath,
 } from "@coremedia/ckeditor5-coremedia-studio-integration/src/content/UriPath";
 import LoggerProvider from "@coremedia/ckeditor5-logging/src/logging/LoggerProvider";
+import { canBeOpenedInTab, openEntitiesInTabs, OpenEntitiesInTabsResult } from "../OpenInTab";
 
 // noinspection JSConstantReassignment
+
 /**
- * The open in tab command.
- * Uses the ServiceAgent to open a content in a CoreMedia Studio tab.
- * Currently used for images and content links.
+ * An abstract command for opening contents in a tab.
+ *
+ * By default, has no value and is always enabled. Provides method
+ * `refreshValueAndEnabledState` to update value and enabled state
+ * based on the given value.
  *
  * @augments module:core/command~Command
  */
 export class OpenInTabCommand extends Command {
   static #logger = LoggerProvider.getLogger("OpenInTabCommand");
-  #elementName: string | undefined;
-  #attributeName: string;
 
   /**
    * Creates an OpenInTabCommand.
@@ -38,76 +38,85 @@ export class OpenInTabCommand extends Command {
    * for textNodes as textNodes are not represented as elements.
    *
    * @param editor - the ckeditor instance
-   * @param attributeName - the name of the attribute which contains the ModelUri.
-   * @param elementName - name of the element in the selection containing the Uri-Path attribute. Defaults to undefined.
    */
-  constructor(editor: Editor, attributeName: string, elementName: string | undefined = undefined) {
+  constructor(editor: Editor) {
     super(editor);
-    this.#elementName = elementName;
-    this.#attributeName = attributeName;
+    // We don't modify any data.
+    this.affectsData = false;
   }
 
-  override refresh(): void {
+  /**
+   * Updates the value and enabled state.
+   *
+   * Only if `valueFromModel` resolves to a content URI, the value of this
+   * command is set accordingly, otherwise set to `undefined`.
+   *
+   * Enabled state in addition to that respects if a referenced content
+   * can be opened. Due to asynchronous behavior to validate content, meanwhile,
+   * a default enabled state is assumed.
+   *
+   * @param valueFromModel - value as retrieved from the model
+   * @param defaultEnabled - default enabled state to take, until ability to
+   * open a given content has been checked.
+   */
+  protected refreshValueAndEnabledState(valueFromModel: unknown, defaultEnabled = true): void {
     const logger = OpenInTabCommand.#logger;
-    const uriPath = this.#resolveUriPath();
+    const uriPath = this.refreshValue(valueFromModel);
+
+    // If this is not a content-URI, no further checks are required if the
+    // OpenInTabCommand is active or not.
     if (!uriPath) {
       this.isEnabled = false;
+      logger.debug(`Disabled command, as URI Path is unavailable for: ${valueFromModel}`);
       return;
     }
 
-    // Please note: WorkAreaService is not observable and therefore, this command
-    // might not update correctly once displayed. You will have to trigger #refresh
-    // manually in order to display the correct content state
-    // (e.g. of a suddenly unreadable content).
-    void serviceAgent.fetchService(createWorkAreaServiceDescriptor()).then((workAreaService): void => {
-      workAreaService
-        .canBeOpenedInTab([uriPath])
-        .then((canBeOpened: unknown) => {
-          logger.debug("May be opened in tab: ", canBeOpened);
-          this.isEnabled = canBeOpened as boolean;
-        })
-        .catch((error): void => {
-          logger.warn(error);
-          this.isEnabled = false;
-        });
+    this.isEnabled = defaultEnabled;
+    logger.debug(`Enabled state set to default: ${defaultEnabled}`);
+
+    void canBeOpenedInTab(uriPath).then((canBeOpened): void => {
+      logger.debug(`Updating enabled state for ${uriPath} to: ${canBeOpened}`);
+      this.isEnabled = canBeOpened;
     });
   }
 
-  override execute(): void {
-    const uriPath = this.#resolveUriPath();
-    serviceAgent
-      .fetchService(createWorkAreaServiceDescriptor())
-      .then(async (workAreaService): Promise<void> => {
-        await workAreaService.openEntitiesInTabs([uriPath]);
-      })
-      .catch((): void => {
-        console.warn("WorkArea Service not available");
-      });
+  /**
+   * Refreshes the command value according to the provided value. Value will
+   * be set to `undefined` if the given value from the model does not represent
+   * a valid URI Path.
+   *
+   * @param valueFromModel - value found in model
+   * @returns value set
+   */
+  protected refreshValue(valueFromModel: unknown): string | undefined {
+    const logger = OpenInTabCommand.#logger;
+    const uriPath = OpenInTabCommand.#toContentUri(valueFromModel);
+    this.value = uriPath;
+    logger.debug(`Value refreshed to: ${uriPath}`);
+    return uriPath;
   }
 
-  #resolveUriPath(): UriPath | undefined {
-    const selection = this.editor.model.document.selection;
-    if (this.#elementName) {
-      const selectedElement = selection.getSelectedElement();
-      if (!selectedElement) {
-        return undefined;
-      }
+  /**
+   * Executes command, either based on URI path set as value or as URI path
+   * given as parameter. Any `uriPath` set explicitly, overrides `uriPath`
+   * derived from model state.
+   *
+   * @param uriPaths - optional URI paths; defaults to the URI path from model
+   * state
+   * @returns Promise, that denotes result of requested URIs to open
+   */
+  override async execute(...uriPaths: string[]): Promise<OpenEntitiesInTabsResult> {
+    const logger = OpenInTabCommand.#logger;
+    const actualUriPaths = uriPaths;
+    const actualValue = this.value;
 
-      const name = selectedElement.name;
-      if (name !== this.#elementName) {
-        return undefined;
-      }
-
-      const modelUriAttributeValue: string = selectedElement.getAttribute(this.#attributeName) as string;
-      return OpenInTabCommand.#toContentUri(modelUriAttributeValue);
+    // Prefer explicitly given uriPaths, use fallback otherwise.
+    if (actualUriPaths.length === 0 && typeof actualValue === "string") {
+      actualUriPaths.push(actualValue);
+      logger.debug(`URI path used from model state: ${actualValue}`);
     }
 
-    // If it is a text we have no element, so we have to go for the first position.
-    const modelUriAttributeValue = selection.getFirstPosition()?.textNode?.getAttribute(this.#attributeName) as string;
-    if (!modelUriAttributeValue) {
-      return undefined;
-    }
-    return OpenInTabCommand.#toContentUri(modelUriAttributeValue);
+    return openEntitiesInTabs(...actualUriPaths);
   }
 
   /**
@@ -122,11 +131,11 @@ export class OpenInTabCommand extends Command {
    * In case the input is of one of these formats, the output is always
    * a UriPath (content/\{id\}). Otherwise undefined is returned.
    *
-   * @param contentUriToParse - the uri string to parse
+   * @param contentUriToParse - the URI string to parse
    * @returns transformed UriPath or undefined if the input string is a non-supported format.
    */
-  static #toContentUri(contentUriToParse: string): UriPath | undefined {
-    if (!CONTENT_URI_PATH_REGEXP.test(contentUriToParse) && !CONTENT_CKE_MODEL_URI_REGEXP.test(contentUriToParse)) {
+  static #toContentUri(contentUriToParse: unknown): UriPath | undefined {
+    if (!isUriPath(contentUriToParse) && !isModelUriPath(contentUriToParse)) {
       return undefined;
     }
 

--- a/packages/ckeditor5-coremedia-content/src/index-doc.ts
+++ b/packages/ckeditor5-coremedia-content/src/index-doc.ts
@@ -5,3 +5,4 @@
  */
 
 export * as commands from "./commands/index-doc";
+export * from "./OpenInTab";

--- a/packages/ckeditor5-coremedia-content/src/index.ts
+++ b/packages/ckeditor5-coremedia-content/src/index.ts
@@ -3,3 +3,10 @@
  */
 
 export { OpenInTabCommand } from "./commands/OpenInTabCommand";
+export {
+  emptyOpenEntitiesInTabsResult,
+  type OpenEntitiesInTabsResult,
+  canBeOpenedInTab,
+  canAllBeOpenedInTab,
+  openEntitiesInTabs,
+} from "./OpenInTab";

--- a/packages/ckeditor5-coremedia-images/src/ContentImageEditingPlugin.ts
+++ b/packages/ckeditor5-coremedia-images/src/ContentImageEditingPlugin.ts
@@ -6,9 +6,12 @@ import ImageUtils from "@ckeditor/ckeditor5-image/src/imageutils";
 import ImageInline from "@ckeditor/ckeditor5-image/src/imageinline";
 import ModelBoundSubscriptionPlugin from "./ModelBoundSubscriptionPlugin";
 import { getOptionalPlugin, reportInitEnd, reportInitStart } from "@coremedia/ckeditor5-core-common/src/Plugins";
-import { OpenInTabCommand } from "@coremedia/ckeditor5-coremedia-content/src/commands/OpenInTabCommand";
 import Logger from "@coremedia/ckeditor5-logging/src/logging/Logger";
 import LoggerProvider from "@coremedia/ckeditor5-logging/src/logging/LoggerProvider";
+import {
+  openImageInTabCommandName,
+  registerOpenImageInTabCommand,
+} from "./contentImageOpenInTab/OpenImageInTabCommand";
 
 /**
  * Plugin to support images from CoreMedia RichText.
@@ -24,7 +27,7 @@ export default class ContentImageEditingPlugin extends Plugin {
   /**
    * Command name for bound `openImageInTab`.
    */
-  static readonly openImageInTab = "openImageInTab" as const;
+  static readonly openImageInTab = openImageInTabCommandName;
   static readonly #logger: Logger = LoggerProvider.getLogger(ContentImageEditingPlugin.pluginName);
 
   static readonly IMAGE_INLINE_MODEL_ELEMENT_NAME = "imageInline";
@@ -37,10 +40,7 @@ export default class ContentImageEditingPlugin extends Plugin {
   init(): void {
     const editor = this.editor;
     const initInformation = reportInitStart(this);
-    editor.commands.add(
-      ContentImageEditingPlugin.openImageInTab,
-      new OpenInTabCommand(editor, "xlink-href", "imageInline")
-    );
+    registerOpenImageInTabCommand(editor);
     reportInitEnd(initInformation);
   }
 

--- a/packages/ckeditor5-coremedia-images/src/augmentation.ts
+++ b/packages/ckeditor5-coremedia-images/src/augmentation.ts
@@ -6,8 +6,8 @@ import type {
   ContentImageOpenInTabUI,
   ContentImagePlugin,
   ModelBoundSubscriptionPlugin,
+  OpenImageInTabCommand,
 } from "./index";
-import type { OpenInTabCommand } from "@coremedia/ckeditor5-coremedia-content/src/commands/OpenInTabCommand";
 
 declare module "@ckeditor/ckeditor5-core" {
   interface PluginsMap {
@@ -18,6 +18,6 @@ declare module "@ckeditor/ckeditor5-core" {
     [ModelBoundSubscriptionPlugin.pluginName]: ModelBoundSubscriptionPlugin;
   }
   interface CommandsMap {
-    [ContentImageEditingPlugin.openImageInTab]: OpenInTabCommand;
+    [ContentImageEditingPlugin.openImageInTab]: OpenImageInTabCommand;
   }
 }

--- a/packages/ckeditor5-coremedia-images/src/contentImageOpenInTab/OpenImageInTabCommand.ts
+++ b/packages/ckeditor5-coremedia-images/src/contentImageOpenInTab/OpenImageInTabCommand.ts
@@ -1,0 +1,78 @@
+import { OpenInTabCommand } from "@coremedia/ckeditor5-coremedia-content/src/commands/OpenInTabCommand";
+import Editor from "@ckeditor/ckeditor5-core/src/editor/editor";
+import ImageUtils from "@ckeditor/ckeditor5-image/src/imageutils";
+import LoggerProvider from "@coremedia/ckeditor5-logging/src/logging/LoggerProvider";
+
+/**
+ * Default command name used to register at editor instance.
+ */
+export const openImageInTabCommandName = "openImageInTab" as const;
+
+/**
+ * A command to open either a given URI path (on `execute`) or the URI path
+ * available in the current model state.
+ */
+export class OpenImageInTabCommand extends OpenInTabCommand {
+  static #logger = LoggerProvider.getLogger("OpenImageInTabCommand");
+
+  override refresh() {
+    const logger = OpenImageInTabCommand.#logger;
+    const { editor } = this;
+    const imageUtils = editor.plugins.get(ImageUtils);
+    const { model } = editor;
+    const { document } = model;
+    const { selection } = document;
+    const element = imageUtils.getClosestSelectedImageElement(selection);
+    if (element) {
+      const xlinkHrefValue = element.getAttribute("xlink-href");
+      this.refreshValueAndEnabledState(xlinkHrefValue);
+      logger.debug(`Enabled state updated according to xlink-href value of "${xlinkHrefValue}": ${this.isEnabled}`);
+    } else {
+      // noinspection JSConstantReassignment
+      this.isEnabled = false;
+      logger.debug("Disable command, as current selection does not represent an image.");
+    }
+  }
+}
+
+/**
+ * Registers the `OpenImageInTabCommand`.
+ *
+ * @param editor - editor instance to register command at
+ * @param name - name of the command
+ */
+export const registerOpenImageInTabCommand = (editor: Editor, name = openImageInTabCommandName) =>
+  editor.commands.add(name, new OpenImageInTabCommand(editor));
+
+/**
+ * Require the command to be available and return it.
+ *
+ * @param editor - editor instance to lookup command at
+ * @param name - name of the command
+ * @throws Error - if the required command is unavailable
+ */
+export const requireOpenImageInTabCommand = (
+  editor: Editor,
+  name = openImageInTabCommandName
+): OpenImageInTabCommand => {
+  const command = editor.commands.get(name);
+  if (!command) {
+    throw new Error(`Missing required command ${name}.`);
+  }
+  return command;
+};
+
+/**
+ * Executes `OpenImageInTabCommand`, if available. Optional URI paths may
+ * be provided to override URI paths as possibly evaluated from the model
+ * state.
+ *
+ * @param editor - editor instance to invoke the command for
+ * @param uriPaths - URI path to open explicitly (overrides the model state)
+ * @param name - name of the command
+ */
+export const executeOpenImageInTabCommand = (
+  editor: Editor,
+  uriPaths: string[] = [],
+  name = openImageInTabCommandName
+) => editor.commands.get(name)?.execute(...uriPaths);

--- a/packages/ckeditor5-coremedia-images/src/contentImageOpenInTab/index-doc.ts
+++ b/packages/ckeditor5-coremedia-images/src/contentImageOpenInTab/index-doc.ts
@@ -4,3 +4,4 @@
  * @module ckeditor5-coremedia-images
  */
 export { default as ContentImageOpenInTabUI } from "./ContentImageOpenInTabUI";
+export * from "./OpenImageInTabCommand";

--- a/packages/ckeditor5-coremedia-images/src/index.ts
+++ b/packages/ckeditor5-coremedia-images/src/index.ts
@@ -7,5 +7,6 @@ export { default as ContentImageEditingPlugin } from "./ContentImageEditingPlugi
 export { default as ContentImageOpenInTabUI } from "./contentImageOpenInTab/ContentImageOpenInTabUI";
 export { default as ContentImagePlugin } from "./ContentImagePlugin";
 export { default as ModelBoundSubscriptionPlugin } from "./ModelBoundSubscriptionPlugin";
+export { OpenImageInTabCommand } from "./contentImageOpenInTab/OpenImageInTabCommand";
 
 import "./augmentation";

--- a/packages/ckeditor5-coremedia-link/src/augmentation.ts
+++ b/packages/ckeditor5-coremedia-link/src/augmentation.ts
@@ -10,9 +10,8 @@ import type {
   LinkTargetCommand,
   LinkTargetModelView,
   LinkUserActionsPlugin,
+  OpenContentInTabCommand,
 } from "./index";
-// TODO[cke] Use index import.
-import type { OpenInTabCommand } from "@coremedia/ckeditor5-coremedia-content/src/commands/OpenInTabCommand";
 
 declare module "@ckeditor/ckeditor5-core" {
   interface PluginsMap {
@@ -31,7 +30,7 @@ declare module "@ckeditor/ckeditor5-core" {
   interface CommandsMap {
     // While part of ckeditor5-coremedia-content, the command is added here
     // within the ContentLinks plugin. Thus, we should declare it here.
-    openLinkInTab: OpenInTabCommand;
+    openLinkInTab: OpenContentInTabCommand;
     linkTarget: LinkTargetCommand;
   }
 }

--- a/packages/ckeditor5-coremedia-link/src/contentlink/ContentLinks.ts
+++ b/packages/ckeditor5-coremedia-link/src/contentlink/ContentLinks.ts
@@ -9,7 +9,6 @@ import ContentLinkClipboardPlugin from "./ContentLinkClipboardPlugin";
 import LinkUserActionsPlugin from "./LinkUserActionsPlugin";
 import { ContextualBalloon } from "@ckeditor/ckeditor5-ui";
 import { CONTENT_CKE_MODEL_URI_REGEXP } from "@coremedia/ckeditor5-coremedia-studio-integration/src/content/UriPath";
-import { OpenInTabCommand } from "@coremedia/ckeditor5-coremedia-content/src/commands/OpenInTabCommand";
 import { serviceAgent } from "@coremedia/service-agent";
 import { addMouseEventListenerToHideDialog, removeInitialMouseDownListener } from "./LinkBalloonEventListenerFix";
 import { createWorkAreaServiceDescriptor } from "@coremedia/ckeditor5-coremedia-studio-integration/src/content/WorkAreaServiceDescriptor";
@@ -22,6 +21,7 @@ import { parseLinkBalloonConfig } from "./LinkBalloonConfig";
 import { hasRequiredInternalLinkUI } from "./InternalLinkUI";
 import { Observable } from "@ckeditor/ckeditor5-utils";
 import { asAugmentedLinkUI, requireNonNullsAugmentedLinkUI } from "./ui/AugmentedLinkUI";
+import { registerOpenContentInTabCommand } from "./OpenContentInTabCommand";
 
 /**
  * This plugin allows content objects to be dropped into the link dialog.
@@ -84,6 +84,8 @@ export default class ContentLinks extends Plugin {
         this.#initialized = true;
       }
     });
+
+    registerOpenContentInTabCommand(editor);
   }
 
   onVisibleViewChanged(linkUI: LinkUI): void {
@@ -114,9 +116,6 @@ export default class ContentLinks extends Plugin {
     if (hasRequiredInternalLinkUI(internalLinkUI)) {
       createDecoratorHook(internalLinkUI, "_hideUI", this.onHideUiCallback(editor), this);
     }
-
-    // registers the openInTab command for content links, used to open a content when clicking the content link
-    editor.commands.add("openLinkInTab", new OpenInTabCommand(editor, "linkHref"));
   }
 
   onHideUiCallback(editor: Editor): () => void {

--- a/packages/ckeditor5-coremedia-link/src/contentlink/OpenContentInTabCommand.ts
+++ b/packages/ckeditor5-coremedia-link/src/contentlink/OpenContentInTabCommand.ts
@@ -1,0 +1,80 @@
+import { OpenInTabCommand } from "@coremedia/ckeditor5-coremedia-content";
+import first from "@ckeditor/ckeditor5-utils/src/first";
+import type Schema from "@ckeditor/ckeditor5-engine/src/model/schema";
+import type ModelElement from "@ckeditor/ckeditor5-engine/src/model/element";
+import Editor from "@ckeditor/ckeditor5-core/src/editor/editor";
+
+/**
+ * Default command name used to register at editor instance.
+ */
+export const openContentInTabCommandName = "openContentInTab";
+
+/**
+ * A command to open either a given URI path (on `execute`) or the URI path
+ * available in the current model state.
+ */
+export class OpenContentInTabCommand extends OpenInTabCommand {
+  override refresh() {
+    const { editor } = this;
+    const { model } = editor;
+    const { schema, document } = model;
+    const { selection } = document;
+    const selectedElement = selection.getSelectedElement() ?? first(selection.getSelectedBlocks());
+
+    // See `LinkCommand.refresh()` for similar implementation.
+    if (isLinkableElement(selectedElement, schema)) {
+      this.refreshValue(selectedElement.getAttribute("linkHref"));
+    } else {
+      this.refreshValue(selection.getAttribute("linkHref"));
+    }
+
+    // Defaults to set enabled state to `true`.
+    super.refresh();
+
+    // DevNote: Enabled State Always `true`
+    // We could consider depending the enabled state depending on if the
+    // model provides a URI path **and** if it can be opened. This would
+    // be helpful if the enabled state is represented in the UI in some way.
+    // In general, there is no harm to "try to open" contents. If any of them
+    // cannot be opened, they just won't open.
+  }
+}
+
+/**
+ * Registers the `OpenContentInTabCommand`.
+ *
+ * @param editor - editor instance to register command at
+ * @param name - name of the command
+ */
+export const registerOpenContentInTabCommand = (editor: Editor, name = openContentInTabCommandName) =>
+  editor.commands.add(name, new OpenContentInTabCommand(editor));
+
+/**
+ * Executes `OpenContentInTabCommand`, if available. Optional URI paths may
+ * be provided to override URI paths as possibly evaluated from the model
+ * state.
+ *
+ * @param editor - editor instance to invoke the command for
+ * @param uriPaths - URI path to open explicitly (overrides the model state)
+ * @param name - name of the command
+ */
+export const executeOpenContentInTabCommand = (
+  editor: Editor,
+  uriPaths: string[] = [],
+  name = openContentInTabCommandName
+) => editor.commands.get(name)?.execute(...uriPaths);
+
+/**
+ * Checks if the given element represents a linkable element. Copy of
+ * the corresponding check in CKEditor 5 Link-Feature.
+ *
+ * @param element - current model element
+ * @param schema - model schema
+ */
+const isLinkableElement = (element: ModelElement | null, schema: Schema): element is ModelElement => {
+  if (!element) {
+    return false;
+  }
+
+  return schema.checkAttribute(element.name, "linkHref");
+};

--- a/packages/ckeditor5-coremedia-link/src/contentlink/index-doc.ts
+++ b/packages/ckeditor5-coremedia-link/src/contentlink/index-doc.ts
@@ -22,3 +22,5 @@ export * as ContentLinkViewUtils from "./ContentLinkViewUtils";
 
 export * from "./LinkBalloonConfig";
 export { default as LinkBalloonConfig } from "./LinkBalloonConfig";
+
+export * from "./OpenContentInTabCommand";

--- a/packages/ckeditor5-coremedia-link/src/contentlink/ui/ContentLinkActionsViewExtension.ts
+++ b/packages/ckeditor5-coremedia-link/src/contentlink/ui/ContentLinkActionsViewExtension.ts
@@ -16,6 +16,7 @@ import { hasContentUriPath } from "./ViewExtensions";
 import { showContentLinkField } from "../ContentLinkViewUtils";
 import { asAugmentedLinkUI, AugmentedLinkUI, requireNonNullsAugmentedLinkUI } from "./AugmentedLinkUI";
 import { AugmentedLinkActionsView } from "./AugmentedLinkActionsView";
+import { executeOpenContentInTabCommand } from "../OpenContentInTabCommand";
 
 /**
  * Extends the action view for Content link display. This includes:
@@ -99,6 +100,7 @@ class ContentLinkActionsViewExtension extends Plugin {
   }
 
   #extendView(linkUI: AugmentedLinkUI, actionsView: AugmentedLinkActionsView): void {
+    const logger = ContentLinkActionsViewExtension.#logger;
     const { formView } = requireNonNullsAugmentedLinkUI(linkUI, "formView");
 
     const contentLinkView = new ContentLinkView(this.editor, {
@@ -110,18 +112,17 @@ class ContentLinkActionsViewExtension extends Plugin {
     });
 
     if (!hasContentUriPath(linkUI.actionsView)) {
-      ContentLinkActionsViewExtension.#logger.warn(
-        "ActionsView does not have a property contentUriPath. Is it already bound?",
-        linkUI.actionsView
-      );
+      logger.warn("ActionsView does not have a property contentUriPath. Is it already bound?", linkUI.actionsView);
       return;
     }
 
     contentLinkView.bind("uriPath").to(actionsView, "contentUriPath");
 
     contentLinkView.on("contentClick", () => {
-      if (contentLinkView.uriPath) {
-        this.editor.commands.get("openLinkInTab")?.execute();
+      const { uriPath } = contentLinkView;
+      if (uriPath) {
+        logger.debug(`Executing OpenContentInTabCommand for: ${uriPath}.`);
+        executeOpenContentInTabCommand(this.editor, [uriPath]);
       }
     });
 

--- a/packages/ckeditor5-coremedia-link/src/contentlink/ui/ContentLinkViewFactory.ts
+++ b/packages/ckeditor5-coremedia-link/src/contentlink/ui/ContentLinkViewFactory.ts
@@ -4,6 +4,8 @@ import ContentLinkView from "./ContentLinkView";
 import { Editor } from "@ckeditor/ckeditor5-core";
 import { requireNonNullsAugmentedLinkUI } from "./AugmentedLinkUI";
 import { LinkUI } from "@ckeditor/ckeditor5-link";
+import LoggerProvider from "@coremedia/ckeditor5-logging/src/logging/LoggerProvider";
+import { executeOpenContentInTabCommand } from "../OpenContentInTabCommand";
 
 /**
  * Creates an ContentLinkView that renders content links in the link form-view.
@@ -15,6 +17,7 @@ import { LinkUI } from "@ckeditor/ckeditor5-link";
  * @param editor - the editor
  */
 const createContentLinkView = (linkUI: LinkUI, editor: Editor): LabeledFieldView => {
+  const logger = LoggerProvider.getLogger("ContentLinkView");
   const { t } = editor.locale;
   const { actionsView, formView } = requireNonNullsAugmentedLinkUI(linkUI, "actionsView", "formView");
 
@@ -39,11 +42,15 @@ const createContentLinkView = (linkUI: LinkUI, editor: Editor): LabeledFieldView
 
   fieldView.bind("uriPath").to(formView, "contentUriPath");
   // Propagate Content Name from ContentLinkView to FormView, as we require to
-  // know the name in some link insertion scenarios.
+  // knowing the name in some link insertion scenarios.
 
   formView.bind("contentName").to(contentLinkView.fieldView);
   fieldView.on("contentClick", () => {
-    linkUI.editor.commands.get("openLinkInTab")?.execute();
+    const { uriPath } = fieldView;
+    if (typeof uriPath === "string") {
+      logger.debug(`Executing OpenContentInTabCommand for: ${uriPath}.`);
+      executeOpenContentInTabCommand(editor, [uriPath]);
+    }
   });
 
   fieldView.on("executeCancel", () => {

--- a/packages/ckeditor5-coremedia-link/src/index.ts
+++ b/packages/ckeditor5-coremedia-link/src/index.ts
@@ -12,6 +12,7 @@ export { default as ContentLinkClipboardPlugin } from "./contentlink/ContentLink
 export { default as ContentLinkCommandHook } from "./contentlink/ContentLinkCommandHook";
 export { default as ContentLinks } from "./contentlink/ContentLinks";
 export { default as LinkUserActionsPlugin } from "./contentlink/LinkUserActionsPlugin";
+export { OpenContentInTabCommand } from "./contentlink/OpenContentInTabCommand";
 export { default as ContentLinkActionsViewExtension } from "./contentlink/ui/ContentLinkActionsViewExtension";
 export { default as ContentLinkFormViewExtension } from "./contentlink/ui/ContentLinkFormViewExtension";
 

--- a/packages/ckeditor5-coremedia-studio-integration-mock/src/content/MockWorkAreaService.ts
+++ b/packages/ckeditor5-coremedia-studio-integration-mock/src/content/MockWorkAreaService.ts
@@ -6,7 +6,6 @@ import WorkAreaService from "@coremedia/ckeditor5-coremedia-studio-integration/s
 import { Editor } from "@ckeditor/ckeditor5-core";
 import MockContentPlugin from "./MockContentPlugin";
 import MockContent from "./MockContent";
-import { BlobType } from "./MutableProperties";
 import LoggerProvider from "@coremedia/ckeditor5-logging/src/logging/LoggerProvider";
 import { Observable, Subject } from "rxjs";
 
@@ -54,13 +53,10 @@ class MockWorkAreaService implements WorkAreaService {
       .map((uri) => mockContentPlugin.getContent(uri))
       .every((mockContent: MockContent): boolean => {
         const allReadable = mockContent.readable.every((isReadable) => isReadable);
-        if (!mockContent.embeddable) {
-          MockWorkAreaService.#LOGGER.debug(`Content is not embeddable and readable is ${allReadable}`);
-          return allReadable;
-        }
-        const dataIsSet = mockContent.blob.every((blobData: BlobType) => blobData?.value);
-        MockWorkAreaService.#LOGGER.debug(`Content is embeddable and readable is ${allReadable}`);
-        return allReadable && dataIsSet;
+        MockWorkAreaService.#LOGGER.debug(
+          `Content ${mockContent.id} is considered ${allReadable ? "" : "un"}readable.`
+        );
+        return allReadable;
       });
   }
 

--- a/packages/ckeditor5-coremedia-studio-integration-mock/src/content/MockWorkAreaService.ts
+++ b/packages/ckeditor5-coremedia-studio-integration-mock/src/content/MockWorkAreaService.ts
@@ -9,6 +9,8 @@ import MockContent from "./MockContent";
 import LoggerProvider from "@coremedia/ckeditor5-logging/src/logging/LoggerProvider";
 import { Observable, Subject } from "rxjs";
 
+const isString = (value: unknown): value is string => typeof value === "string";
+
 class MockWorkAreaService implements WorkAreaService {
   static #LOGGER = LoggerProvider.getLogger("WorkAreaService");
   readonly #editor: Editor;
@@ -25,8 +27,10 @@ class MockWorkAreaService implements WorkAreaService {
     this.#activeEntitySubject = new Subject<unknown>();
   }
 
-  async openEntitiesInTabs(entities: unknown[]): Promise<unknown> {
-    entities.forEach((entity: unknown): void => {
+  async openEntitiesInTabs(entities: unknown[]): Promise<{ accepted: string[]; rejected: string[] }> {
+    const accepted: string[] = [];
+    entities.filter(isString).forEach((entity: string): void => {
+      accepted.push(entity);
       const node: Element = document.createElement("DIV");
       node.classList.add("notification");
       const textNode: Text = document.createTextNode(`Open Content ${entity} in Studio Tab`);
@@ -39,14 +43,14 @@ class MockWorkAreaService implements WorkAreaService {
     });
 
     this.lastOpenedEntities = entities;
-    return { success: true };
+    return { accepted, rejected: [] };
   }
 
   getLastOpenedEntities(): unknown[] {
     return this.lastOpenedEntities;
   }
 
-  async canBeOpenedInTab(entityUris: unknown[]): Promise<unknown> {
+  async canBeOpenedInTab(entityUris: unknown[]): Promise<boolean> {
     const mockContentPlugin = this.#editor.plugins.get(MockContentPlugin.pluginName) as MockContentPlugin;
     const uris = entityUris as string[];
     return uris

--- a/packages/ckeditor5-coremedia-studio-integration-mock/src/content/MockWorkAreaService.ts
+++ b/packages/ckeditor5-coremedia-studio-integration-mock/src/content/MockWorkAreaService.ts
@@ -1,4 +1,4 @@
-/* async: Methods require to be asynchronous in production scenario. */
+/* async: Methods require to be asynchronous in a production scenario. */
 /* eslint-disable @typescript-eslint/require-await */
 /* eslint no-restricted-globals: off */
 
@@ -13,12 +13,12 @@ class MockWorkAreaService implements WorkAreaService {
   static #LOGGER = LoggerProvider.getLogger("WorkAreaService");
   readonly #editor: Editor;
   /**
-   * The entities which were triggered to open latest.
+   * The entities that were triggered to open latest.
    * Used for testing purposes to verify if the openEntitiesInTab has been triggered.
    */
   lastOpenedEntities: unknown[] = [];
 
-  #activeEntitySubject: Subject<unknown>;
+  readonly #activeEntitySubject: Subject<unknown>;
 
   constructor(editor: Editor) {
     this.#editor = editor;
@@ -29,8 +29,8 @@ class MockWorkAreaService implements WorkAreaService {
     entities.forEach((entity: unknown): void => {
       const node: Element = document.createElement("DIV");
       node.classList.add("notification");
-      const textnode: Text = document.createTextNode(`Open Content ${entity} in Studio Tab`);
-      node.appendChild(textnode);
+      const textNode: Text = document.createTextNode(`Open Content ${entity} in Studio Tab`);
+      node.appendChild(textNode);
       document.getElementById("notifications")?.appendChild(node);
       this.#activeEntitySubject.next([entity]);
       setTimeout(() => {

--- a/packages/ckeditor5-coremedia-studio-integration-mock/src/content/PredefinedMockContents.ts
+++ b/packages/ckeditor5-coremedia-studio-integration-mock/src/content/PredefinedMockContents.ts
@@ -81,6 +81,12 @@ const DOCUMENT_MOCKS: PredefinedMockContentConfig[] = [
     editing: [true, false],
     readable: [true, true, true, false, false, false],
   },
+  {
+    id: 114,
+    comment: "Single letter (unicode symbol) name.",
+    name: "\u{1F54A}",
+    editing: [true, false],
+  },
 ];
 const NAME_CHALLENGE_MOCKS: PredefinedMockContentConfig[] = [
   {

--- a/packages/ckeditor5-coremedia-studio-integration/src/content/studioservices/WorkAreaService.ts
+++ b/packages/ckeditor5-coremedia-studio-integration/src/content/studioservices/WorkAreaService.ts
@@ -18,7 +18,11 @@ interface WorkAreaService {
    *
    * @returns the promise indicating success or failure.
    */
-  openEntitiesInTabs(entities: unknown[], background?: boolean, options?: unknown): Promise<unknown>;
+  openEntitiesInTabs(
+    entities: unknown[],
+    background?: boolean,
+    options?: unknown
+  ): Promise<{ accepted: string[]; rejected: string[] }>;
 
   /**
    * Determines whether entities given by their REST URIs can be opened in a tab.
@@ -26,7 +30,7 @@ interface WorkAreaService {
    * @param entityUris - the entities given by their URIs.
    * @returns the promise holding whether the entities can be opened in a tab
    */
-  canBeOpenedInTab(entityUris: unknown[]): Promise<unknown>;
+  canBeOpenedInTab(entityUris: unknown[]): Promise<boolean>;
 
   /**
    * Observes the currently active work area entity.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -432,9 +432,6 @@ importers:
       '@ckeditor/ckeditor5-core':
         specifier: ^37.0.1
         version: 37.0.1
-      '@ckeditor/ckeditor5-ui':
-        specifier: ^37.0.1
-        version: 37.0.1
       '@coremedia-internal/ckeditor5-jest-test-helpers':
         specifier: ^1.0.0
         version: link:../ckeditor5-jest-test-helpers


### PR DESCRIPTION
> **Merge #145 first!**
>
> This is a rewrite of #146, as the original PR highly collides with changes for CKE5 37.x. When merged, change the base to `main`.

## The Issue

Given you moved the caret via cursor keys into a link-selection, and you opened the link balloon via Ctrl+K, you may have observed, that opening the link via mouse click failed.

The reason were improper updates of the enabled state of the corresponding command.

## The Fix

The fix mostly consists of refactoring to align detection of related model elements with corresponding features for images and links, as they ship with CKEditor 5. For the central issue, we completely disabled tracking the enabled state for now, as it was for no gain: The UI did not and does not represent a disabled state for unreadable or not existing referenced contents. As long as we don't require this, there is no need of tracking this information via disabled state.

## Suggested Release: Patch

While a lot of API aspects changed around the `OpenInTabCommand`, the API is not considered public by means to be extended or to be used directly. Thus, we consider this a patch release, as it fixes an observable bug.

## Minor Adaptations

### WorkAreaService

Adjusted the forward reference to `WorkAreaService` in CoreMedia CMS according to the provided values, which means, especially, that `openEntitiesInTab` returns a state of successfully opened and not opened (rejected) contents.

### MockWorkAreaService

Fixed `canBeOpenedInTab` to not respect for images, if BLOB data have been set at corresponding image content. This is irrelevant for being able to open a content and causes surprising effects in example-app.

## Remark on Enabled State

Analyzing the example app, you will notice (at least for the image balloon), that the "Open in Content" icon does not update its enabled state when a content gets destroyed or moved to an unreadable location (according to permissions of the corresponding editor).

We do not consider this an issue yet, as balloons are meant to stay open only a short period of time. Next time, when reopening the balloon, the state will have been updated accordingly.

## See Also

* Replaces: #146
