### PR TITLE
fix(link): Augmentation in CommandsMap wrong for OpenContentInTab

### DIFF
--- a/packages/ckeditor5-coremedia-link/src/augmentation.ts
+++ b/packages/ckeditor5-coremedia-link/src/augmentation.ts
@@ -30,7 +30,7 @@ declare module "@ckeditor/ckeditor5-core" {
   interface CommandsMap {
     // While part of ckeditor5-coremedia-content, the command is added here
     // within the ContentLinks plugin. Thus, we should declare it here.
-    openLinkInTab: OpenContentInTabCommand;
+    [ContentLinks.openLinkInTab]: OpenContentInTabCommand;
     linkTarget: LinkTargetCommand;
   }
 }

--- a/packages/ckeditor5-coremedia-link/src/contentlink/ContentLinks.ts
+++ b/packages/ckeditor5-coremedia-link/src/contentlink/ContentLinks.ts
@@ -21,7 +21,7 @@ import { parseLinkBalloonConfig } from "./LinkBalloonConfig";
 import { hasRequiredInternalLinkUI } from "./InternalLinkUI";
 import { Observable } from "@ckeditor/ckeditor5-utils";
 import { asAugmentedLinkUI, requireNonNullsAugmentedLinkUI } from "./ui/AugmentedLinkUI";
-import { registerOpenContentInTabCommand } from "./OpenContentInTabCommand";
+import { openContentInTabCommandName, registerOpenContentInTabCommand } from "./OpenContentInTabCommand";
 
 /**
  * This plugin allows content objects to be dropped into the link dialog.
@@ -29,6 +29,8 @@ import { registerOpenContentInTabCommand } from "./OpenContentInTabCommand";
  */
 export default class ContentLinks extends Plugin {
   public static readonly pluginName = "ContentLinks" as const;
+
+  static readonly openLinkInTab = openContentInTabCommandName;
 
   #logger = LoggerProvider.getLogger(ContentLinks.pluginName);
   #serviceRegisteredSubscription: Subscription | undefined = undefined;

--- a/packages/ckeditor5-coremedia-link/src/contentlink/OpenContentInTabCommand.ts
+++ b/packages/ckeditor5-coremedia-link/src/contentlink/OpenContentInTabCommand.ts
@@ -8,7 +8,7 @@ import { UriPath } from "@coremedia/ckeditor5-coremedia-studio-integration";
 /**
  * Default command name used to register at editor instance.
  */
-export const openContentInTabCommandName = "openContentInTab";
+export const openContentInTabCommandName = "openContentInTab" as const;
 
 /**
  * A command to open either a given URI path (on `execute`) or the URI path

--- a/packages/ckeditor5-coremedia-link/src/contentlink/ui/ContentLinkActionsViewExtension.ts
+++ b/packages/ckeditor5-coremedia-link/src/contentlink/ui/ContentLinkActionsViewExtension.ts
@@ -121,7 +121,13 @@ class ContentLinkActionsViewExtension extends Plugin {
       if (uriPath) {
         logger.debug(`Executing OpenContentInTabCommand for: ${uriPath}.`);
         const uriPaths: UriPath[] = [requireContentUriPath(uriPath)];
-        executeOpenContentInTabCommand(this.editor, uriPaths);
+        executeOpenContentInTabCommand(this.editor, uriPaths)
+          ?.then((result) => {
+            logger.debug("Result for OpenContentInTabCommand by click:", result);
+          })
+          .catch((reason) => {
+            logger.warn("Failed executing OpenContentInTabCommand invoked by click:", reason);
+          });
       }
     });
 

--- a/packages/ckeditor5-coremedia-link/src/contentlink/ui/ContentLinkViewFactory.ts
+++ b/packages/ckeditor5-coremedia-link/src/contentlink/ui/ContentLinkViewFactory.ts
@@ -50,7 +50,13 @@ const createContentLinkView = (linkUI: LinkUI, editor: Editor): LabeledFieldView
     const { uriPath } = fieldView;
     if (typeof uriPath === "string") {
       logger.debug(`Executing OpenContentInTabCommand for: ${uriPath}.`);
-      executeOpenContentInTabCommand(editor, [requireContentUriPath(uriPath)]);
+      executeOpenContentInTabCommand(editor, [requireContentUriPath(uriPath)])
+        ?.then((result) => {
+          logger.debug("Result for OpenContentInTabCommand by click:", result);
+        })
+        .catch((reason) => {
+          logger.warn("Failed executing OpenContentInTabCommand invoked by click:", reason);
+        });
     }
   });
 


### PR DESCRIPTION
`CommandsMap` for command `openContentInTab` erroneously referenced to the command as `openLinkInTab`. This has been fixed.

Along with that, enhanced debugging for execution of that command, which may be helpful, if `openInTab` fails when invoked in context of CoreMedia Studio via its `WorkAreaService`.