### PR TITLE
fix(hide balloon): Hide balloon on active tab change

### DIFF
--- a/packages/ckeditor5-coremedia-link/src/contentlink/ContentLinks.ts
+++ b/packages/ckeditor5-coremedia-link/src/contentlink/ContentLinks.ts
@@ -82,19 +82,10 @@ export default class ContentLinks extends Plugin {
     const contextualBalloon: ContextualBalloon = editor.plugins.get(ContextualBalloon);
     contextualBalloon.on("change:visibleView", (evt, name, visibleView) => {
       if (visibleView && visibleView === linkUI.actionsView && !this.#initialized) {
-        this.onVisibleViewChanged(linkUI);
+        this.initializeLinkBalloonListeners(linkUI);
         this.#initialized = true;
       }
     });
-
-    registerOpenContentInTabCommand(editor);
-  }
-
-  onVisibleViewChanged(linkUI: LinkUI): void {
-    const { editor } = linkUI;
-    removeInitialMouseDownListener(linkUI);
-    addMouseEventListenerToHideDialog(linkUI);
-    parseLinkBalloonConfig(editor.config);
 
     const onServiceRegisteredFunction = (services: WorkAreaService[]): void => {
       if (services.length === 0) {
@@ -113,6 +104,14 @@ export default class ContentLinks extends Plugin {
       .observeServices<WorkAreaService>(createWorkAreaServiceDescriptor())
       .subscribe(onServiceRegisteredFunction);
 
+    registerOpenContentInTabCommand(editor);
+  }
+
+  initializeLinkBalloonListeners(linkUI: LinkUI): void {
+    const { editor } = linkUI;
+    removeInitialMouseDownListener(linkUI);
+    addMouseEventListenerToHideDialog(linkUI);
+    parseLinkBalloonConfig(editor.config);
     const internalLinkUI: Observable = linkUI;
 
     if (hasRequiredInternalLinkUI(internalLinkUI)) {


### PR DESCRIPTION
In CoreMedia Studio, balloons must be hidden manually to disappear when the active Studio tab changes. In this case, no mouse click, that would usually close the balloon, appears. This was previously fixed in the link balloon init method, that got called as soon as a link balloon was opened. However, we also need this fix when using the image balloon (open image in tab). This use case did not work anymore, after refactoring the workspace as part of a CKEditor upgrade.

We now listen to active tab changes in the link plugin as soon as the link plugin is initialized and don't wait for the balloon to be opened.