### PR TITLE
Feature(link): Default target configuration

### DIFF
--- a/app/src/ckeditor.ts
+++ b/app/src/ckeditor.ts
@@ -269,6 +269,12 @@ ClassicEditor.create(sourceElement, {
   },
   link: {
     defaultProtocol: "https://",
+    /*defaultTargets: [
+      {
+        type: "externalLink",
+        target: "_blank",
+      },
+    ],*/
     ...linkAttributesConfig,
     /*decorators: {
       hasTitle: {

--- a/packages/ckeditor5-coremedia-link/__tests__/linktarget/config/LinkDefaultTargetsConfig.test.ts
+++ b/packages/ckeditor5-coremedia-link/__tests__/linktarget/config/LinkDefaultTargetsConfig.test.ts
@@ -1,0 +1,42 @@
+/* eslint no-null/no-null: off */
+
+import Config from "@ckeditor/ckeditor5-utils/src/config";
+import { computeDefaultLinkTargetForUrl } from "../../../src/linktarget/config/LinkTargetConfig";
+
+jest.mock("@ckeditor/ckeditor5-utils/src/config");
+
+describe("LinkTargetDefaultsConfig", () => {
+  describe("computeDefaultLinkTargetForUrl", () => {
+    // @ts-expect-error - Requires generic type since CKEditor 37.x.
+    let config: Config;
+
+    beforeEach(() => {
+      config = new Config();
+    });
+
+    test.each`
+      url                          | expectedTarget
+      ${"content:123"}             | ${"_embed"}
+      ${"https://www.example.com"} | ${"_blank"}
+      ${"unexpectedFormat"}        | ${undefined}
+    `("[$#] For the url `$url` a target with the value '$expectedTarget' is expected.", ({ url, expectedTarget }) => {
+      config.set("link.defaultTargets", [
+        {
+          type: "externalLink",
+          target: "_toBeOverridden",
+        },
+        {
+          type: "externalLink",
+          target: "_blank",
+        },
+        {
+          type: "contentLink",
+          target: "_embed",
+        },
+      ]);
+
+      const target = computeDefaultLinkTargetForUrl(url, config);
+      expect(target).toStrictEqual(expectedTarget);
+    });
+  });
+});

--- a/packages/ckeditor5-coremedia-link/src/augmentation.ts
+++ b/packages/ckeditor5-coremedia-link/src/augmentation.ts
@@ -12,6 +12,9 @@ import type {
   LinkUserActionsPlugin,
   OpenContentInTabCommand,
 } from "./index";
+import DefaultTarget from "./linktarget/config/DefaultTarget";
+import LinkTargetOptionDefinition from "./linktarget/config/LinkTargetOptionDefinition";
+import { TargetDefaultRuleDefinition } from "./linktarget/config/LinkTargetDefaultRuleDefinition";
 
 declare module "@ckeditor/ckeditor5-core" {
   interface PluginsMap {
@@ -32,5 +35,12 @@ declare module "@ckeditor/ckeditor5-core" {
     // within the ContentLinks plugin. Thus, we should declare it here.
     [ContentLinks.openLinkInTab]: OpenContentInTabCommand;
     linkTarget: LinkTargetCommand;
+  }
+}
+
+declare module "@ckeditor/ckeditor5-link" {
+  interface LinkConfig {
+    targets?: (DefaultTarget | LinkTargetOptionDefinition)[];
+    defaultTargets?: TargetDefaultRuleDefinition[];
   }
 }

--- a/packages/ckeditor5-coremedia-link/src/linktarget/LinkTargetModelView.ts
+++ b/packages/ckeditor5-coremedia-link/src/linktarget/LinkTargetModelView.ts
@@ -5,6 +5,8 @@ import { LINK_TARGET_MODEL, LINK_TARGET_VIEW } from "./Constants";
 import LinkTargetCommand from "./command/LinkTargetCommand";
 import { reportInitEnd, reportInitStart } from "@coremedia/ckeditor5-core-common/src/Plugins";
 import { getLinkAttributes, LinkAttributes } from "@coremedia/ckeditor5-link-common/src/LinkAttributes";
+import { Range } from "@ckeditor/ckeditor5-engine";
+import { computeDefaultLinkTargetForUrl } from "./config/LinkTargetConfig";
 
 /**
  * Adds an attribute `linkTarget` to the model, which will be represented
@@ -21,6 +23,9 @@ export default class LinkTargetModelView extends Plugin {
   /**
    * Defines `linkTarget` model-attribute, which is represented on downcast
    * (to data and for editing) as `target` attribute.
+   *
+   * Also registers a postFixer to change the default link target like specified
+   * in the editor config.
    */
   init(): Promise<void> | void {
     const initInformation = reportInitStart(this);
@@ -33,6 +38,47 @@ export default class LinkTargetModelView extends Plugin {
     });
 
     editor.commands.add("linkTarget", new LinkTargetCommand(editor));
+
+    // This function, as well as the postFixer are used to apply default link targets to links in the editor.
+    const addLinkTarget = (linkTarget: string, range: Range) => {
+      this.editor.model.change((writer) => {
+        writer.setAttribute("linkTarget", linkTarget, range);
+      });
+    };
+
+    this.editor.model.document.registerPostFixer((writer) => {
+      const changes = this.editor.model.document.differ.getChanges();
+
+      for (const entry of changes) {
+        if (entry.type === "attribute" && entry.attributeKey === "linkHref") {
+          // The linkHref attribute was added/changed for this node
+          // This might happen if an existing link gets edited e.g. if the link url gets changed.
+          const linkTarget = computeDefaultLinkTargetForUrl(entry.attributeNewValue as string, this.editor.config);
+          if (!linkTarget) {
+            continue;
+          }
+          addLinkTarget(linkTarget, entry.range);
+        } else if (entry.type === "insert" && entry.attributes.has("linkHref")) {
+          // An entry with linkHref attribute was inserted
+          // This applies to links, created via the link balloon and contents dropped into the
+          // editor or into the link balloon
+          const linkTarget = computeDefaultLinkTargetForUrl(
+            entry.attributes.get("linkHref") as string,
+            this.editor.config
+          );
+          if (!linkTarget) {
+            continue;
+          }
+
+          const { position: start } = entry;
+          const end = start.getShiftedBy(entry.length);
+          const range = writer.createRange(start, end);
+
+          addLinkTarget(linkTarget, range);
+        }
+      }
+      return false;
+    });
 
     reportInitEnd(initInformation);
   }

--- a/packages/ckeditor5-coremedia-link/src/linktarget/README.md
+++ b/packages/ckeditor5-coremedia-link/src/linktarget/README.md
@@ -19,6 +19,7 @@ the `LinkActionsView` of CKEditor's link feature.
     * [_embed][]
     * [_other][]
   * [Advanced Configuration][]
+  * [Default-Target Configuration][]
 * [CoreMedia RichText 1.0 Integration][]
   * [CKEditor 4 Behavior][]
 
@@ -42,6 +43,9 @@ ClassicEditor
       targets: [
         // ...
       ],
+      defaultTargets: [
+        // ...
+      ]
     }
   })
   .then(...)
@@ -63,7 +67,7 @@ The plugin can be configured as part of CKEditor's Link Feature configuration.
 
 [Default Configuration]: <#default-configuration>
 
-| [[Top][] | [Up][Configuration] | [Default Configuration][] | [Advanced Configuration][] |
+| [Top][] | [Up][Configuration] | [Default Configuration][] | [Advanced Configuration][] | [Default-Target Configuration][] |
 
 The following example shows the default configuration, which is applied, if no
 configuration is given:
@@ -233,7 +237,7 @@ mapping from `xlink:show` and `xlink:role` as required for CoreMedia RichText
 
 [Advanced Configuration]: <#advanced-configuration>
 
-| [Top][] | [Up][Configuration] | [Default Configuration][] | [Advanced Configuration][] |
+| [Top][] | [Up][Configuration] | [Default Configuration][] | [Advanced Configuration][] | [Default-Target Configuration][] |
 
 You may add any custom button for predefined `linkTarget` values. For example to
 support standard HTML option values `_top` and `_parent` you may add them to the
@@ -295,6 +299,59 @@ The title defaults to the name of the target option if unset.
 
 **icon:** Icons will be scaled to 20×20. Thus, it is recommended providing SVGs
 having this initial size.
+
+### Default-Target Configuration
+
+[Default-Target Configuration]: <#default-target-configuration>
+
+| [Top][] | [Up][Configuration] | [Default Configuration][] | [Advanced Configuration][] | [Default-Target Configuration][] |
+
+You can add defaults for link targets. These ```defaultTargets``` define how a 
+link is opened, based on the ```type``` of the link. The config for these targets
+distinguishes between content links and external links, where content links are
+all links to contents in CoreMedia Studio and external links are links, prefixed
+with ```https://```.
+
+```typescript
+ClassicEditor
+  .create(document.querySelector("#editor"), {
+    // ...
+    link: {
+      defaultTargets: [
+        {
+          type: "externalLink",
+          target: "_blank"
+        }
+      ],
+    }
+  })
+  .then(...)
+  .catch(...);
+```
+
+Please note, that you can also set a ```filter``` property instead of a ```type```
+to specify additional default targets:
+
+```typescript
+ClassicEditor
+  .create(document.querySelector("#editor"), {
+    // ...
+    link: {
+      defaultTargets: [
+        {
+          filter: (url: string) => (url ? url.startsWith("http://") : false),
+          target: "_embed"
+        }
+      ],
+    }
+  })
+  .then(...)
+  .catch(...);
+```
+
+It's important to know that the order of default targets is relevant. For each
+link, all target rules will be applied in the exact order, determined by the config.
+If there are multiple matching types or filters, the last one will always be applied.
 
 ## CoreMedia RichText 1.0 Integration
 

--- a/packages/ckeditor5-coremedia-link/src/linktarget/config/LinkTargetConfig.ts
+++ b/packages/ckeditor5-coremedia-link/src/linktarget/config/LinkTargetConfig.ts
@@ -12,7 +12,8 @@ import {
 } from "./LinkTargetDefaultRuleDefinition";
 
 /**
- * Provides the given targets to select from.
+ * Provides the given targets to select from and a list of rules to
+ * set the default target for different types of links.
  *
  * The configuration is provided as extension to CKEditor's link feature
  * configuration:
@@ -41,6 +42,12 @@ import {
  *                 title: "Custom Target",
  *               },
  *             ],
+ *             defaultTargets: [
+ *               {
+ *                 type: "externalLink",
+ *                 target: "_blank",
+ *               }
+ *             ]
  *         }
  *     } )
  *     .then( ... )
@@ -51,6 +58,9 @@ import {
  * this plugin, while `"myCustomTarget"` provides a custom fixed target.
  * `"myCustomTarget"` will be represented in model by `linkTarget="myCustomTarget"`
  * and will get a toggle button with given icon and title.
+ *
+ * It is also possible to provide a `filter` instead of a `type`
+ * for the default target rules.
  */
 interface LinkTargetConfig {
   targets?: (DefaultTarget | LinkTargetOptionDefinition)[];

--- a/packages/ckeditor5-coremedia-link/src/linktarget/config/LinkTargetDefaultRuleDefinition.ts
+++ b/packages/ckeditor5-coremedia-link/src/linktarget/config/LinkTargetDefaultRuleDefinition.ts
@@ -1,0 +1,68 @@
+export type TargetDefaultRuleDefinition = TargetDefaultRuleDefinitionWithFilter | TargetDefaultRuleDefinitionWithType;
+
+/**
+ *
+ */
+export interface TargetDefaultRuleDefinitionWithFilter {
+  /**
+   * A filter rule, used to check whether the given default target should be applied to the link.
+   *
+   * Please note: Since content links and external links are the most common types to
+   * have a particular link target, you can also use the "type" property to configure them directly.
+   *
+   * This filter would apply to all content links:
+   * @example
+   * ```
+   * filter: (url: string) => (url ? url.startsWith("content:") : false);
+   * ```
+   *
+   * @param url - the url of the link
+   * @returns whether to apply the target to the link
+   */
+  filter: (url: string) => boolean;
+
+  /**
+   * The link target, that should be applied to all inserted links, that match
+   * the filter rule.
+   */
+  target: string;
+}
+
+export interface TargetDefaultRuleDefinitionWithType {
+  /**
+   * The type of the link to apply the target to.
+   */
+  type: "externalLink" | "contentLink";
+
+  /**
+   * The link target, that should be applied to all inserted links, that match
+   * the given type.
+   */
+  target: string;
+}
+
+/**
+ * Type-guard for TargetDefaultRuleDefinitionWithFilter type
+ * @param value - the variable to check
+ */
+export const isTargetDefaultRuleDefinitionWithFilter = (
+  value: unknown
+): value is TargetDefaultRuleDefinitionWithFilter => {
+  if (typeof value !== "object" || !value) {
+    return false;
+  }
+  return !(!("filter" in value) || !("target" in value));
+};
+
+/**
+ * Type-guard for TargetDefaultRuleDefinitionWithType type
+ * @param value - the variable to check
+ */
+export const isTargetDefaultRuleDefinitionWithType = (
+  value: unknown
+): value is TargetDefaultRuleDefinitionWithType => {
+  if (typeof value !== "object" || !value) {
+    return false;
+  }
+  return !(!("type" in value) || !("target" in value));
+};

--- a/packages/ckeditor5-coremedia-link/src/linktarget/config/index-doc.ts
+++ b/packages/ckeditor5-coremedia-link/src/linktarget/config/index-doc.ts
@@ -11,3 +11,5 @@ export { default as LinkTargetConfig } from "./LinkTargetConfig";
 
 export * from "./LinkTargetOptionDefinition";
 export { default as LinkTargetOptionDefinition } from "./LinkTargetOptionDefinition";
+
+export * from "./LinkTargetDefaultRuleDefinition";

--- a/packages/ckeditor5-jest-test-helpers/shared-jest.config.js
+++ b/packages/ckeditor5-jest-test-helpers/shared-jest.config.js
@@ -12,14 +12,9 @@ module.exports = {
   transform: {
     // '^.+\\.[tj]sx?$' to process js/ts with `ts-jest`
     // '^.+\\.m?[tj]sx?$' to process js/ts/mjs/mts with `ts-jest`
-    "^.+\\.tsx?$": [
-      "ts-jest",
-      {
-        // ts-jest configuration goes here
-      },
-    ],
+
     // Required, e.g., for CKEditor 5 Dependencies.
-    "^.+\\.jsx?$": [require.resolve("babel-jest"), babelConfig],
+    "^.+\\.[jt]sx?$": [require.resolve("babel-jest"), babelConfig],
     // https://www.npmjs.com/package/jest-transform-stub
     "^.+\\.(css|less|sass|scss|gif|png|jpg|ttf|eot|woff|woff2|svg)$": require.resolve("jest-transform-stub"),
   },


### PR DESCRIPTION
Since it is a common use-case, we provide a configuration for the default target of links.
The default target can be set, depending on the url of the link, or by differentiating between external links and links to content items.