### PR TITLE
Feature(link): Default target configuration

### DIFF
--- a/app/src/ckeditor.ts
+++ b/app/src/ckeditor.ts
@@ -269,6 +269,12 @@ ClassicEditor.create(sourceElement, {
   },
   link: {
     defaultProtocol: "https://",
+    /*defaultTargets: [
+      {
+        type: "externalLink",
+        target: "_blank",
+      },
+    ],*/
     ...linkAttributesConfig,
     /*decorators: {
       hasTitle: {

--- a/packages/ckeditor5-coremedia-link/__tests__/linktarget/config/LinkDefaultTargetsConfig.test.ts
+++ b/packages/ckeditor5-coremedia-link/__tests__/linktarget/config/LinkDefaultTargetsConfig.test.ts
@@ -1,0 +1,41 @@
+/* eslint no-null/no-null: off */
+
+import Config from "@ckeditor/ckeditor5-utils/src/config";
+import { computeDefaultLinkTargetForUrl } from "../../../src/linktarget/config/LinkTargetConfig";
+
+jest.mock("@ckeditor/ckeditor5-utils/src/config");
+
+describe("LinkTargetDefaultsConfig", () => {
+  describe("computeDefaultLinkTargetForUrl", () => {
+    // @ts-expect-error - Requires generic type since CKEditor 37.x.
+    let config: Config;
+
+    beforeEach(() => {
+      config = new Config();
+      config.set("link.defaultTargets", [
+        {
+          type: "externalLink",
+          target: "_toBeOverridden",
+        },
+        {
+          type: "externalLink",
+          target: "_blank",
+        },
+        {
+          type: "contentLink",
+          target: "_embed",
+        },
+      ]);
+    });
+
+    test.each`
+      url                          | expectedTarget
+      ${"content:123"}             | ${"_embed"}
+      ${"https://www.example.com"} | ${"_blank"}
+      ${"unexpectedFormat"}        | ${undefined}
+    `("[$#] For the url `$url` a target with the value '$expectedTarget' is expected.", ({ url, expectedTarget }) => {
+      const target = computeDefaultLinkTargetForUrl(url, config);
+      expect(target).toStrictEqual(expectedTarget);
+    });
+  });
+});

--- a/packages/ckeditor5-coremedia-link/src/augmentation.ts
+++ b/packages/ckeditor5-coremedia-link/src/augmentation.ts
@@ -12,6 +12,9 @@ import type {
   LinkUserActionsPlugin,
   OpenContentInTabCommand,
 } from "./index";
+import DefaultTarget from "./linktarget/config/DefaultTarget";
+import LinkTargetOptionDefinition from "./linktarget/config/LinkTargetOptionDefinition";
+import { TargetDefaultRuleDefinition } from "./linktarget/config/LinkTargetDefaultRuleDefinition";
 
 declare module "@ckeditor/ckeditor5-core" {
   interface PluginsMap {
@@ -32,5 +35,12 @@ declare module "@ckeditor/ckeditor5-core" {
     // within the ContentLinks plugin. Thus, we should declare it here.
     [ContentLinks.openLinkInTab]: OpenContentInTabCommand;
     linkTarget: LinkTargetCommand;
+  }
+}
+
+declare module "@ckeditor/ckeditor5-link" {
+  interface LinkConfig {
+    targets?: (DefaultTarget | LinkTargetOptionDefinition)[];
+    defaultTargets?: TargetDefaultRuleDefinition[];
   }
 }

--- a/packages/ckeditor5-coremedia-link/src/linktarget/LinkTargetModelView.ts
+++ b/packages/ckeditor5-coremedia-link/src/linktarget/LinkTargetModelView.ts
@@ -5,6 +5,9 @@ import { LINK_TARGET_MODEL, LINK_TARGET_VIEW } from "./Constants";
 import LinkTargetCommand from "./command/LinkTargetCommand";
 import { reportInitEnd, reportInitStart } from "@coremedia/ckeditor5-core-common/src/Plugins";
 import { getLinkAttributes, LinkAttributes } from "@coremedia/ckeditor5-link-common/src/LinkAttributes";
+import { DiffItemAttribute, Range, Writer } from "@ckeditor/ckeditor5-engine";
+import { computeDefaultLinkTargetForUrl } from "./config/LinkTargetConfig";
+import { DiffItem, DiffItemInsert } from "@ckeditor/ckeditor5-engine/src/model/differ";
 
 /**
  * Adds an attribute `linkTarget` to the model, which will be represented
@@ -21,6 +24,9 @@ export default class LinkTargetModelView extends Plugin {
   /**
    * Defines `linkTarget` model-attribute, which is represented on downcast
    * (to data and for editing) as `target` attribute.
+   *
+   * Also registers a postFixer to change the default link target like specified
+   * in the editor config.
    */
   init(): Promise<void> | void {
     const initInformation = reportInitStart(this);
@@ -34,6 +40,92 @@ export default class LinkTargetModelView extends Plugin {
 
     editor.commands.add("linkTarget", new LinkTargetCommand(editor));
 
+    /**
+     * This function is used in the postFixer, registered further below.
+     * The postFixer checks, if a change includes a link and computes the default link target.
+     * Afterwards, this function is called to apply the target to the link element in the model.
+     *
+     * @param linkTarget - the computed link target
+     * @param range - the range of the changed element
+     */
+    const addLinkTarget = (linkTarget: string, range: Range) => {
+      this.editor.model.change((writer) => {
+        writer.setAttribute("linkTarget", linkTarget, range);
+      });
+    };
+
+    this.editor.model.document.registerPostFixer((writer) => {
+      const changes = this.editor.model.document.differ.getChanges();
+
+      for (const entry of changes) {
+        const linkTarget = this.#computeLinkTarget(entry);
+        if (!linkTarget) {
+          continue;
+        }
+        const range = this.#getLinkRange(entry, writer);
+        addLinkTarget(linkTarget, range);
+      }
+      return false;
+    });
+
     reportInitEnd(initInformation);
+  }
+
+  /**
+   * Type-guard for DiffItemAttribute type
+   * @param diffItem - the variable to check
+   */
+  #isDiffItemAttribute(diffItem: DiffItem): diffItem is DiffItemAttribute {
+    return diffItem.type === "attribute" && diffItem.attributeKey === "linkHref";
+  }
+
+  /**
+   * Type-guard for DiffItemInsert type
+   * @param diffItem - the variable to check
+   */
+  #isDiffItemInsert(diffItem: DiffItem): diffItem is DiffItemInsert {
+    return diffItem.type === "insert" && diffItem.attributes.has("linkHref");
+  }
+
+  /**
+   * Computes the range for any inserted or edited link elements.
+   * @param diffItem - the diffItem to be checked
+   * @param writer - the writer, needed to create a range for inserted links
+   * @returns the rangeor undefined
+   * @private
+   */
+  #getLinkRange(diffItem: DiffItem, writer: Writer): Range {
+    if (this.#isDiffItemAttribute(diffItem)) {
+      return diffItem.range;
+    }
+    const { position: start } = diffItem;
+    const end = start.getShiftedBy(diffItem.length);
+    return writer.createRange(start, end);
+  }
+
+  /**
+   * Computes a default link target for any inserted or edited link elements.
+   * @param diffItem - the diffItem to be checked
+   * @returns the link target or undefined
+   * @private
+   */
+  #computeLinkTarget(diffItem: DiffItem): string | undefined {
+    if (this.#isDiffItemAttribute(diffItem)) {
+      // The linkHref attribute was added/changed for this node
+      // This might happen if an existing link gets edited e.g. if the link url gets changed.
+      const linkTarget = computeDefaultLinkTargetForUrl(diffItem.attributeNewValue as string, this.editor.config);
+      return linkTarget;
+    }
+
+    if (this.#isDiffItemInsert(diffItem)) {
+      // An entry with linkHref attribute was inserted
+      // This applies to links, created via the link balloon and contents dropped into the
+      // editor or into the link balloon
+      const linkTarget = computeDefaultLinkTargetForUrl(
+        diffItem.attributes.get("linkHref") as string,
+        this.editor.config
+      );
+      return linkTarget;
+    }
   }
 }

--- a/packages/ckeditor5-coremedia-link/src/linktarget/LinkTargetModelView.ts
+++ b/packages/ckeditor5-coremedia-link/src/linktarget/LinkTargetModelView.ts
@@ -91,7 +91,7 @@ export default class LinkTargetModelView extends Plugin {
    * Computes the range for any inserted or edited link elements.
    * @param diffItem - the diffItem to be checked
    * @param writer - the writer, needed to create a range for inserted links
-   * @returns the rangeor undefined
+   * @returns the range or undefined
    * @private
    */
   #getLinkRange(diffItem: DiffItem, writer: Writer): Range {
@@ -113,19 +113,14 @@ export default class LinkTargetModelView extends Plugin {
     if (this.#isDiffItemAttribute(diffItem)) {
       // The linkHref attribute was added/changed for this node
       // This might happen if an existing link gets edited e.g. if the link url gets changed.
-      const linkTarget = computeDefaultLinkTargetForUrl(diffItem.attributeNewValue as string, this.editor.config);
-      return linkTarget;
+      return computeDefaultLinkTargetForUrl(diffItem.attributeNewValue as string, this.editor.config);
     }
 
     if (this.#isDiffItemInsert(diffItem)) {
       // An entry with linkHref attribute was inserted
       // This applies to links, created via the link balloon and contents dropped into the
       // editor or into the link balloon
-      const linkTarget = computeDefaultLinkTargetForUrl(
-        diffItem.attributes.get("linkHref") as string,
-        this.editor.config
-      );
-      return linkTarget;
+      return computeDefaultLinkTargetForUrl(diffItem.attributes.get("linkHref") as string, this.editor.config);
     }
   }
 }

--- a/packages/ckeditor5-coremedia-link/src/linktarget/README.md
+++ b/packages/ckeditor5-coremedia-link/src/linktarget/README.md
@@ -19,6 +19,7 @@ the `LinkActionsView` of CKEditor's link feature.
     * [_embed][]
     * [_other][]
   * [Advanced Configuration][]
+  * [Default-Target Configuration][]
 * [CoreMedia RichText 1.0 Integration][]
   * [CKEditor 4 Behavior][]
 
@@ -42,6 +43,9 @@ ClassicEditor
       targets: [
         // ...
       ],
+      defaultTargets: [
+        // ...
+      ]
     }
   })
   .then(...)
@@ -63,7 +67,7 @@ The plugin can be configured as part of CKEditor's Link Feature configuration.
 
 [Default Configuration]: <#default-configuration>
 
-| [[Top][] | [Up][Configuration] | [Default Configuration][] | [Advanced Configuration][] |
+| [Top][] | [Up][Configuration] | [Default Configuration][] | [Advanced Configuration][] | [Default-Target Configuration][] |
 
 The following example shows the default configuration, which is applied, if no
 configuration is given:
@@ -233,7 +237,7 @@ mapping from `xlink:show` and `xlink:role` as required for CoreMedia RichText
 
 [Advanced Configuration]: <#advanced-configuration>
 
-| [Top][] | [Up][Configuration] | [Default Configuration][] | [Advanced Configuration][] |
+| [Top][] | [Up][Configuration] | [Default Configuration][] | [Advanced Configuration][] | [Default-Target Configuration][] |
 
 You may add any custom button for predefined `linkTarget` values. For example to
 support standard HTML option values `_top` and `_parent` you may add them to the
@@ -295,6 +299,59 @@ The title defaults to the name of the target option if unset.
 
 **icon:** Icons will be scaled to 20×20. Thus, it is recommended providing SVGs
 having this initial size.
+
+### Default-Target Configuration
+
+[Default-Target Configuration]: <#default-target-configuration>
+
+| [Top][] | [Up][Configuration] | [Default Configuration][] | [Advanced Configuration][] | [Default-Target Configuration][] |
+
+You can add defaults for link targets. These ```defaultTargets``` define how a
+link is opened, based on the ```type``` of the link. The config for these targets
+distinguishes between content links and external links, where content links are
+all links to contents in CoreMedia Studio and external links are links, prefixed
+with ```https://```.
+
+```typescript
+ClassicEditor
+  .create(document.querySelector("#editor"), {
+    // ...
+    link: {
+      defaultTargets: [
+        {
+          type: "externalLink",
+          target: "_blank"
+        }
+      ],
+    }
+  })
+  .then(...)
+  .catch(...);
+```
+
+Please note, that you can also set a ```filter``` property instead of a ```type```
+to specify additional default targets:
+
+```typescript
+ClassicEditor
+  .create(document.querySelector("#editor"), {
+    // ...
+    link: {
+      defaultTargets: [
+        {
+          filter: (url: string) => (url ? url.startsWith("http://") : false),
+          target: "_embed"
+        }
+      ],
+    }
+  })
+  .then(...)
+  .catch(...);
+```
+
+It's important to know that the order of default targets is relevant. For each
+link, all target rules will be applied in the exact order, determined by the config.
+If there are multiple matching types or filters, the last one will always be applied.
 
 ## CoreMedia RichText 1.0 Integration
 

--- a/packages/ckeditor5-coremedia-link/src/linktarget/config/DefaultTargetTypeFilters.ts
+++ b/packages/ckeditor5-coremedia-link/src/linktarget/config/DefaultTargetTypeFilters.ts
@@ -1,0 +1,33 @@
+import { DefaultLinkType } from "./LinkTargetDefaultRuleDefinition";
+
+/**
+ * Checks if a given url is an external link.
+ *
+ * @param url - the href attribute of the link
+ * @returns whether the filter applies on the given url
+ */
+const externalLinkFilter = (url: string) => (url ? url.startsWith("https://") : false);
+
+/**
+ * Checks if a given url is a (internal) content link.
+ *
+ * @param url - the href attribute of the link
+ * @returns whether the filter applies on the given url
+ */
+const contentLinkFilter = (url: string) => (url ? url.startsWith("content") : false);
+
+/**
+ * Returns a matching filter
+ * @param type - the type of the link
+ * @returns the matching filter
+ */
+export const getFilterByType = (type: DefaultLinkType): ((url: string) => boolean) | undefined => {
+  switch (type) {
+    case "externalLink":
+      return externalLinkFilter;
+    case "contentLink":
+      return contentLinkFilter;
+    default:
+      return undefined;
+  }
+};

--- a/packages/ckeditor5-coremedia-link/src/linktarget/config/LinkTargetConfig.ts
+++ b/packages/ckeditor5-coremedia-link/src/linktarget/config/LinkTargetConfig.ts
@@ -79,6 +79,10 @@ const parseDefaultLinkTargetConfig = (config: Config<EditorConfig>): TargetDefau
   const fromConfig: unknown = config.get("link.defaultTargets");
   const result: TargetDefaultRuleDefinitionWithFilter[] = [];
 
+  if (fromConfig === null || fromConfig === undefined) {
+    return [];
+  }
+
   if (!Array.isArray(fromConfig)) {
     throw new Error(
       `link.defaultTargets: Unexpected configuration. Array expected but is: ${JSON.stringify(fromConfig)}`

--- a/packages/ckeditor5-coremedia-link/src/linktarget/config/LinkTargetConfig.ts
+++ b/packages/ckeditor5-coremedia-link/src/linktarget/config/LinkTargetConfig.ts
@@ -13,7 +13,8 @@ import {
 import { getFilterByType } from "./DefaultTargetTypeFilters";
 
 /**
- * Provides the given targets to select from.
+ * Provides the given targets to select from and a list of rules to
+ * set the default target for different types of links.
  *
  * The configuration is provided as extension to CKEditor's link feature
  * configuration:
@@ -42,6 +43,12 @@ import { getFilterByType } from "./DefaultTargetTypeFilters";
  *                 title: "Custom Target",
  *               },
  *             ],
+ *             defaultTargets: [
+ *               {
+ *                 type: "externalLink",
+ *                 target: "_blank",
+ *               }
+ *             ]
  *         }
  *     } )
  *     .then( ... )
@@ -52,6 +59,9 @@ import { getFilterByType } from "./DefaultTargetTypeFilters";
  * this plugin, while `"myCustomTarget"` provides a custom fixed target.
  * `"myCustomTarget"` will be represented in model by `linkTarget="myCustomTarget"`
  * and will get a toggle button with given icon and title.
+ *
+ * It is also possible to provide a `filter` instead of a `type`
+ * for the default target rules.
  */
 interface LinkTargetConfig {
   targets?: (DefaultTarget | LinkTargetOptionDefinition)[];

--- a/packages/ckeditor5-coremedia-link/src/linktarget/config/LinkTargetConfig.ts
+++ b/packages/ckeditor5-coremedia-link/src/linktarget/config/LinkTargetConfig.ts
@@ -4,6 +4,13 @@ import LinkTargetOptionDefinition from "./LinkTargetOptionDefinition";
 import DefaultTarget, { DEFAULT_TARGETS_ARRAY, getDefaultTargetDefinition } from "./DefaultTarget";
 import { Config } from "@ckeditor/ckeditor5-utils";
 import { EditorConfig } from "@ckeditor/ckeditor5-core/src/editor/editorconfig";
+import {
+  isTargetDefaultRuleDefinitionWithFilter,
+  isTargetDefaultRuleDefinitionWithType,
+  TargetDefaultRuleDefinition,
+  TargetDefaultRuleDefinitionWithFilter,
+} from "./LinkTargetDefaultRuleDefinition";
+import { getFilterByType } from "./DefaultTargetTypeFilters";
 
 /**
  * Provides the given targets to select from.
@@ -48,7 +55,64 @@ import { EditorConfig } from "@ckeditor/ckeditor5-core/src/editor/editorconfig";
  */
 interface LinkTargetConfig {
   targets?: (DefaultTarget | LinkTargetOptionDefinition)[];
+  defaultTargets?: TargetDefaultRuleDefinition[];
 }
+
+/**
+ * Parses a possibly existing configuration option as part of CKEditor's
+ * link plugin configuration. It expects an entry `defaultTargets` which contains an
+ * array of default targets for different kind of link types.
+ *
+ * @param config - CKEditor configuration to parse
+ */
+const parseDefaultLinkTargetConfig = (config: Config<EditorConfig>): TargetDefaultRuleDefinitionWithFilter[] => {
+  const fromConfig: unknown = config.get("link.defaultTargets");
+  const result: TargetDefaultRuleDefinitionWithFilter[] = [];
+
+  if (!Array.isArray(fromConfig)) {
+    throw new Error(
+      `link.defaultTargets: Unexpected configuration. Array expected but is: ${JSON.stringify(fromConfig)}`
+    );
+  }
+  const defaultTargetsArray: unknown[] = fromConfig;
+  defaultTargetsArray.forEach((entry: unknown): void => {
+    if (isTargetDefaultRuleDefinitionWithFilter(entry)) {
+      result.push(entry);
+    }
+
+    if (isTargetDefaultRuleDefinitionWithType(entry)) {
+      const filter = getFilterByType(entry.type);
+      if (!filter) {
+        return;
+      }
+
+      result.push({
+        filter,
+        target: entry.target,
+      });
+    }
+  });
+
+  return result;
+};
+
+/**
+ * Returns a default target for a given url, based on the link configuration.
+ *
+ * @param url - the url of the link
+ * @param config - the editor config
+ * @returns the default linkTarget or undefined if no matching filter rule exists
+ */
+export const computeDefaultLinkTargetForUrl = (url: string, config: Config<EditorConfig>): string | undefined => {
+  const defaultTargetConfig = parseDefaultLinkTargetConfig(config);
+  let result: string | undefined;
+  defaultTargetConfig.forEach((defaultTarget) => {
+    if (defaultTarget.filter(url)) {
+      result = defaultTarget.target;
+    }
+  });
+  return result;
+};
 
 /**
  * Parses a possibly existing configuration option as part of CKEditor's

--- a/packages/ckeditor5-coremedia-link/src/linktarget/config/LinkTargetDefaultRuleDefinition.ts
+++ b/packages/ckeditor5-coremedia-link/src/linktarget/config/LinkTargetDefaultRuleDefinition.ts
@@ -1,0 +1,71 @@
+export type TargetDefaultRuleDefinition = TargetDefaultRuleDefinitionWithFilter | TargetDefaultRuleDefinitionWithType;
+
+/**
+ * A filter rule, used to check whether the given default target should be applied to the link.
+ * This rule is based on a filter, which, if applies to the given url, sets the target attribute of the link.
+ */
+export interface TargetDefaultRuleDefinitionWithFilter {
+  /**
+   * Please note: Since content links and external links are the most common types to
+   * have a particular link target, you can also use the "type" property to configure them directly.
+   *
+   * This filter would apply to all content links:
+   * @example
+   * ```
+   * filter: (url: string) => (url ? url.startsWith("content:") : false);
+   * ```
+   *
+   * @param url - the url of the link
+   * @returns whether to apply the target to the link
+   */
+  filter: (url: string) => boolean;
+
+  /**
+   * The link target, that should be applied to all inserted links, that match
+   * the filter rule.
+   */
+  target: string;
+}
+
+export type DefaultLinkType = "externalLink" | "contentLink";
+
+/**
+ * A filter rule, used to check whether the given default target should be applied to the link.
+ * This rule is based on a type, that translates to a default filter rule, which sets the target attribute of the link.
+ */
+export interface TargetDefaultRuleDefinitionWithType {
+  /**
+   * The type of the link to apply the target to.
+   */
+  type: DefaultLinkType;
+
+  /**
+   * The link target, that should be applied to all inserted links, that match
+   * the given type.
+   */
+  target: string;
+}
+
+/**
+ * Type-guard for TargetDefaultRuleDefinitionWithFilter type
+ * @param value - the variable to check
+ */
+export const isTargetDefaultRuleDefinitionWithFilter = (
+  value: unknown
+): value is TargetDefaultRuleDefinitionWithFilter => {
+  if (typeof value !== "object" || !value) {
+    return false;
+  }
+  return !(!("filter" in value) || !("target" in value));
+};
+
+/**
+ * Type-guard for TargetDefaultRuleDefinitionWithType type
+ * @param value - the variable to check
+ */
+export const isTargetDefaultRuleDefinitionWithType = (value: unknown): value is TargetDefaultRuleDefinitionWithType => {
+  if (typeof value !== "object" || !value) {
+    return false;
+  }
+  return !(!("type" in value) || !("target" in value));
+};

--- a/packages/ckeditor5-coremedia-link/src/linktarget/config/index-doc.ts
+++ b/packages/ckeditor5-coremedia-link/src/linktarget/config/index-doc.ts
@@ -11,3 +11,6 @@ export { default as LinkTargetConfig } from "./LinkTargetConfig";
 
 export * from "./LinkTargetOptionDefinition";
 export { default as LinkTargetOptionDefinition } from "./LinkTargetOptionDefinition";
+
+export * from "./DefaultTargetTypeFilters";
+export * from "./LinkTargetDefaultRuleDefinition";


### PR DESCRIPTION
Since it is a common use-case, we provide a configuration for the default target of links.
The default target can be set, depending on the url of the link, or by differentiating between external links and links to content items.