### PR TITLE
Fixes export 'UriPath' ... was not found in './content/UriPath' warning during build

### DIFF
--- a/packages/ckeditor5-coremedia-link/src/contentlink/ui/ContentLinkActionsViewExtension.ts
+++ b/packages/ckeditor5-coremedia-link/src/contentlink/ui/ContentLinkActionsViewExtension.ts
@@ -5,7 +5,8 @@ import { LinkUI } from "@ckeditor/ckeditor5-link";
 // LinkActionsView: See ckeditor/ckeditor5#12027.
 import LinkActionsView from "@ckeditor/ckeditor5-link/src/ui/linkactionsview";
 import ContentLinkView from "./ContentLinkView";
-import { requireContentUriPath, isModelUriPath, UriPath } from "@coremedia/ckeditor5-coremedia-studio-integration";
+import { requireContentUriPath, isModelUriPath } from "@coremedia/ckeditor5-coremedia-studio-integration";
+import type { UriPath } from "@coremedia/ckeditor5-coremedia-studio-integration";
 import { reportInitEnd, reportInitStart } from "@coremedia/ckeditor5-core-common/src/Plugins";
 import { handleFocusManagement } from "@coremedia/ckeditor5-link-common/src/FocusUtils";
 import { ContextualBalloon } from "@ckeditor/ckeditor5-ui";

--- a/packages/ckeditor5-coremedia-studio-integration/src/index.ts
+++ b/packages/ckeditor5-coremedia-studio-integration/src/index.ts
@@ -9,8 +9,7 @@ export { default as RichtextConfigurationService } from "./content/RichtextConfi
 export { createRichtextConfigurationServiceDescriptor } from "./content/RichtextConfigurationServiceDescriptor";
 
 // Helpers
-export { UriPath } from "./content/UriPath";
-export { requireContentUriPath } from "./content/UriPath";
-export { isModelUriPath } from "./content/UriPath";
+export type { UriPath } from "./content/UriPath";
+export { isModelUriPath, requireContentUriPath } from "./content/UriPath";
 
 export { default as ContentAsLink } from "./content/ContentAsLink";


### PR DESCRIPTION
Exporting the UriPath via default named exports leads to a warning during a build. 
The better way of importing/exporting types is to use the "type" prefix to ensure the import is only present in TypeScript files.