### PR TITLE
feat: Handle Artificial xlink:role values (Opt-In)

### DIFF
--- a/packages/ckeditor5-common/package.json
+++ b/packages/ckeditor5-common/package.json
@@ -10,6 +10,11 @@
     "pnpm": "^8.1"
   },
   "license": "Apache-2.0",
+  "main": "./src/index.ts",
+  "publishConfig": {
+    "main": "./src/index.js",
+    "types": "./src/index.d.ts"
+  },
   "devDependencies": {
     "@coremedia-internal/ckeditor5-jest-test-helpers": "^1.0.0",
     "@types/jest": "^29.5.1",

--- a/packages/ckeditor5-common/src/AdvancedTypes.ts
+++ b/packages/ckeditor5-common/src/AdvancedTypes.ts
@@ -43,3 +43,9 @@ export const isRaw = <T>(value: unknown, ...requiredProperties: (keyof T)[]): va
   }
   return false;
 };
+
+/**
+ * Utility type to mark selected properties as required.
+ */
+export type RequireSelected<Type extends object, Key extends keyof Type> = Pick<Type, keyof Omit<Type, Key>> &
+  Required<Pick<Type, Key>>;

--- a/packages/ckeditor5-common/src/index.ts
+++ b/packages/ckeditor5-common/src/index.ts
@@ -1,0 +1,7 @@
+/**
+ * General utilities, e.g., for TypeScript Support.
+ *
+ * @module ckeditor5-common
+ */
+
+export type { RequireSelected } from "./AdvancedTypes";

--- a/packages/ckeditor5-coremedia-richtext/__tests__/rules/AnchorElements.test.ts
+++ b/packages/ckeditor5-coremedia-richtext/__tests__/rules/AnchorElements.test.ts
@@ -205,7 +205,7 @@ describe("AnchorElement", () => {
       aut.anchorElements,
       /*
        * Stores artificial `xlink:role` as class token with prefix `role_` in
-       * `toView` processing and later restores in from `class` attribute in
+       * `toView` processing and later restores it from `class` attribute in
        * `toData` processing.
        *
        * Note: If this configuration changes, please review the TSdoc of

--- a/packages/ckeditor5-coremedia-richtext/src/index.ts
+++ b/packages/ckeditor5-coremedia-richtext/src/index.ts
@@ -42,5 +42,10 @@ export {
   replaceHeadingsByElementAndClass,
   type ReplaceHeadingsByElementAndClassConfig,
 } from "./rules/ReplaceHeadingsByElementAndClass";
+export {
+  mapArtificialXLinkRole,
+  preProcessAnchorElement,
+  type HTMLAnchorElementPreprocessor,
+} from "./rules/AnchorElements";
 
 import "./augmentation";

--- a/packages/ckeditor5-coremedia-richtext/src/rules/AnchorElements.ts
+++ b/packages/ckeditor5-coremedia-richtext/src/rules/AnchorElements.ts
@@ -155,52 +155,47 @@ export const formatTarget = (attributes: Pick<XLinkAttributes, "role" | "show">)
   const { show, role } = attributes;
   let target = "";
 
-  if (!show) {
-    if (role) {
-      // artificial state, which should not happen (but may happen due to UAPI calls).
-      target = `_role_${role}`;
-    }
-  } else {
-    // Signals, if to (still) handle the role. May be reset, once the role
-    // has been handled. Signals an artificial state if the role is unexpected
-    // for a given show attribute (like "replace").
-    let handleRole = !!role;
-    switch (show.toLowerCase()) {
-      case "replace":
-        target = "_self";
-        break;
-      case "new":
-        target = "_blank";
-        break;
-      case "embed":
-        target = "_embed";
-        break;
-      case "none":
-        target = "_none";
-        break;
-      case "other":
-        if (!role) {
-          target = "_other";
-        } else {
-          target = role;
-          handleRole = false;
-        }
-        break;
-      default:
-        if (handleRole) {
-          target = `_role_${role}`;
-          console.warn(`Invalid value for xlink:show="${show}". Only xlink:role respected in target attribute.`);
-        } else {
-          console.warn(`Invalid value for xlink:show="${show}". Empty target provided.`);
-        }
+  const normalizedShow = show?.toLowerCase().trim() ?? "";
+  const hasShow = !!normalizedShow;
+
+  // Signals, if to (still) handle the role. May be reset, once the role
+  // has been handled. Signals an artificial state if the role is unexpected
+  // for a given show attribute (like "replace").
+  let handleRole = !!role;
+  switch (normalizedShow) {
+    case "replace":
+      target = "_self";
+      break;
+    case "new":
+      target = "_blank";
+      break;
+    case "embed":
+      target = "_embed";
+      break;
+    case "none":
+      target = "_none";
+      break;
+    case "other":
+      if (!role) {
+        target = "_other";
+      } else {
+        target = role;
         handleRole = false;
-    }
-    if (handleRole) {
-      target = `${target}_${role}`;
-      console.info(
-        `Unexpected xlink:role="${role}" for xlink:show="${show}". Providing artificial target="${target}".`
-      );
-    }
+      }
+      break;
+    default:
+      if (handleRole) {
+        target = `_role_${role}`;
+        hasShow &&
+          console.warn(`Invalid value for xlink:show="${show}". Only xlink:role respected in target attribute.`);
+      } else {
+        hasShow && console.warn(`Invalid value for xlink:show="${show}". Empty target provided.`);
+      }
+      handleRole = false;
+  }
+  if (handleRole) {
+    target = `${target}_${role}`;
+    console.info(`Unexpected xlink:role="${role}" for xlink:show="${show}". Providing artificial target="${target}".`);
   }
   return target;
 };

--- a/packages/ckeditor5-coremedia-richtext/src/rules/AnchorElements.ts
+++ b/packages/ckeditor5-coremedia-richtext/src/rules/AnchorElements.ts
@@ -161,7 +161,7 @@ export const formatTarget = (attributes: Pick<XLinkAttributes, "role" | "show">)
   // Signals, if to (still) handle the role. May be reset, once the role
   // has been handled. Signals an artificial state if the role is unexpected
   // for a given show attribute (like "replace").
-  let handleRole = !!role;
+  let hasUnhandledRole = !!role;
   switch (normalizedShow) {
     case "replace":
       target = "_self";
@@ -180,23 +180,27 @@ export const formatTarget = (attributes: Pick<XLinkAttributes, "role" | "show">)
         target = "_other";
       } else {
         target = role;
-        handleRole = false;
+        hasUnhandledRole = false;
       }
       break;
     default:
-      if (handleRole) {
-        target = `_role_${role}`;
-        hasShow &&
-          console.warn(`Invalid value for xlink:show="${show}". Only xlink:role respected in target attribute.`);
-      } else {
-        hasShow && console.warn(`Invalid value for xlink:show="${show}". Empty target provided.`);
-      }
-      handleRole = false;
+      hasShow && console.warn(`Ignoring unsupported value for xlink:show="${show}".`);
   }
-  if (handleRole) {
-    target = `${target}_${role}`;
-    console.info(`Unexpected xlink:role="${role}" for xlink:show="${show}". Providing artificial target="${target}".`);
+
+  const hasParsedShow = !!target;
+
+  if (hasUnhandledRole) {
+    if (hasParsedShow) {
+      target = `${target}_${role}`;
+      console.info(
+        `Unexpected xlink:role="${role}" for xlink:show="${show}". Providing artificial target="${target}".`
+      );
+    } else {
+      target = `_role_${role}`;
+      console.warn(`Unexpected xlink:role="${role}". Providing artificial target="${target}".`);
+    }
   }
+
   return target;
 };
 

--- a/packages/ckeditor5-coremedia-richtext/src/rules/XLink.ts
+++ b/packages/ckeditor5-coremedia-richtext/src/rules/XLink.ts
@@ -1,4 +1,5 @@
 import { capitalize } from "@coremedia/ckeditor5-common/src/Strings";
+import { describeAttr } from "@coremedia/ckeditor5-dom-support";
 
 export const xLinkNamespaceUri = "http://www.w3.org/1999/xlink" as const;
 export const xLinkPrefix = "xlink" as const;
@@ -66,7 +67,13 @@ export const setXLinkAttributes = (element: Element, attributes: XLinkAttributes
       const qualifiedName: XLinkAttributeQualifiedName = `${xLinkPrefix}:${key}`;
       const xlinkAttribute = ownerDocument.createAttributeNS(xLinkNamespaceUri, qualifiedName);
       xlinkAttribute.value = value;
-      element.setAttributeNodeNS(xlinkAttribute);
+      const previousNode = element.setAttributeNodeNS(xlinkAttribute);
+      if (previousNode) {
+        // This may happen if some other data-processing already set a value here.
+        console.debug(
+          `Overwriting existing attribute node ${describeAttr(previousNode)} by ${describeAttr(xlinkAttribute)}.`
+        );
+      }
     }
   });
 };

--- a/packages/ckeditor5-dom-converter/package.json
+++ b/packages/ckeditor5-dom-converter/package.json
@@ -28,6 +28,7 @@
     "@ckeditor/ckeditor5-utils": "^37.0.1"
   },
   "dependencies": {
+    "@coremedia/ckeditor5-common": "15.0.2-rc.2",
     "@coremedia/ckeditor5-dom-support": "15.0.2-rc.2",
     "@coremedia/ckeditor5-logging": "15.0.2-rc.2"
   },

--- a/packages/ckeditor5-dom-converter/src/Rule.ts
+++ b/packages/ckeditor5-dom-converter/src/Rule.ts
@@ -6,6 +6,7 @@ import {
   ImportedWithChildrenFunction,
   PrepareFunction,
 } from "./DomConverterStages";
+import { RequireSelected } from "@coremedia/ckeditor5-common";
 
 export interface RuleConfigBase {
   /**
@@ -21,12 +22,6 @@ export interface RuleConfigBase {
    */
   priority?: PriorityString;
 }
-
-/**
- * Utility type to mark selected properties as required.
- */
-export type RequireSelected<Type extends object, Key extends keyof Type> = Pick<Type, keyof Omit<Type, Key>> &
-  Required<Pick<Type, Key>>;
 
 /**
  * A rule configuration containing related `toData` and `toView` mapping

--- a/packages/ckeditor5-dom-support/src/Attrs.ts
+++ b/packages/ckeditor5-dom-support/src/Attrs.ts
@@ -22,3 +22,14 @@ export const copyAttributesFrom = (source: Element, target: Element): void => {
     target.setAttributeNodeNS(importedAttribute);
   }
 };
+
+/**
+ * Provide some description for the given attribute suitable for debugging
+ * purpose.
+ *
+ * @param attr - attribute to describe
+ */
+export const describeAttr = (attr: Attr): string => {
+  const { localName, value, prefix, name, namespaceURI } = attr;
+  return `Attr(${JSON.stringify({ namespaceURI, prefix, localName, name, value })})`;
+};

--- a/packages/ckeditor5-dom-support/src/index.ts
+++ b/packages/ckeditor5-dom-support/src/index.ts
@@ -2,7 +2,7 @@
  * @module ckeditor5-dom-support
  */
 
-export { copyAttributesFrom } from "./Attrs";
+export { copyAttributesFrom, describeAttr } from "./Attrs";
 export { fragmentFromNodeContents, fragmentToString } from "./DocumentFragments";
 export { documentFromHtml, documentFromXml } from "./Documents";
 export {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1013,6 +1013,9 @@ importers:
 
   packages/ckeditor5-dom-converter:
     dependencies:
+      '@coremedia/ckeditor5-common':
+        specifier: 15.0.2-rc.2
+        version: link:../ckeditor5-common
       '@coremedia/ckeditor5-dom-support':
         specifier: 15.0.2-rc.2
         version: link:../ckeditor5-dom-support


### PR DESCRIPTION
## Motivation

`xlink:show` and `xlink:role` have a combined semantic within CoreMedia Rich Text 1.0. If `xlink:show` is set to `"other"`, it is expected, that `xlink:role` contains a non-empty value, that is typically rendered as `target` attribute when delivering the Rich Text on websites. We do the same in the view layers of CKEditor 5.

For any other valid value of `xlink:show` the behavior for any non-empty value of `xlink:role` is not specified. The default implementation of the Rich Text data-processor assumes this to be an artificial/unexpected state and tries to preserve it, by encoding it into the `target` attribute to preserve its state.

Having this, the following represents an _artificial `xlink:role`:_

```xml
<?xml version="1.0" encoding="utf-8"?>
<div xmlns="http://www.coremedia.com/2003/richtext-1.0" xmlns:xlink="http://www.w3.org/1999/xlink">
    <p>
        <a xlink:show="embed" xlink:role="artificial" xlink:href="https://example.org/">Lorem</a>
    </p>
</div>
```

This is represented in view layers of CKEditor 5 by default as:

```html
<a href="https://example.org/" target="_embed_artificial">Lorem</a>
```

But, as the behavior for any other value of `xlink:show` than `"other"` is unspecified, it may have been used to encode any other relevant state for rendering when delivering your website. You may have used the `xlink:role`, for example, to store the `download` attribute state in data (which does not exist in CoreMedia Rich Text 1.0).

This is, when you may use the new provided feature.

## Solution

The core of the solution is a new method `mapArtificialXLinkRole` in module `@coremedia/ckeditor5-coremedia-richtext`. It is a factory method creating a data-processing rule-configuration based on your provided mapping functions.

This again is based on a new method `preProcessAnchorElement` that is guaranteed to provide a rule capable of intervening the `target` ↔ (`xlink:show`, `xlink:role`) processing and applying some DOM modifications prior to these default mapping rules.

## Examples

### Remove Artificial `xlink:role`

With all defaults applied, `mapArtificialXLinkRole` will create a rule, that just removes any artificial `xlink:role` in `toView` processing and does nothing on `toData` processing.

The following example shows, how you may adapt the existing `ckeditor.ts` (Example App) to perform such sanitation:

```typescript
import { mapArtificialXLinkRole } from "@coremedia/ckeditor5-coremedia-richtext";

/**
 * Apply custom mapping rules.
 */
const richTextRuleConfigurations: RuleConfig[] = [
  // ...
  mapArtificialXLinkRole(),
];
```

### Store In `class` Attribute

While not being a recommended mapping, the following example spares some additional required steps for alternative mappings (see note below): It will store an artificial `xlink:role` in `class` attribute as an additional token (`toView` mapping). Later, on `toData` processing, it will parse the `class` attribute and possibly restore the corresponding `xlinK:role` attribute value.

```typescript
import { mapArtificialXLinkRole } from "@coremedia/ckeditor5-coremedia-richtext";

/**
 * Apply custom mapping rules.
 */
const richTextRuleConfigurations: RuleConfig[] = [
  // ...
  mapArtificialXLinkRole({
    toView: (element, role) => {
      const sanitizedRole = role.replaceAll(/\s/g, "_");
      element.classList.add(`role_${sanitizedRole}`);
    },
    toData: (element) => {
      const matcher = /^role_(\S*)$/;
      const matchedClasses: string[] = [];
      let role: string | undefined;
      for (const cls of element.classList) {
        const match = cls.match(matcher);
        if (match) {
          const [matchedCls, matchedRole] = match;
          role = matchedRole;
          matchedClasses.push(matchedCls);
        }
      }
      // Clean-up any matched classes and possibly left-over `class=""`.
      element.classList.remove(...matchedClasses);
      if (element.classList.length === 0) {
        element.removeAttribute("class");
      }
      return role;
    },
  }),
];
```

> - - - - -
> **Note:**
>
> For any mapping you choose in the view layer/the model layer of CKEditor 5, you must ensure to bind, for example, the `download` attribute (continuing the use-case from _Motivation_ section) as to _belong to the link_. Otherwise, you may observe effects such as left-over attributes when unlinking or orphaned attribute added when typing right before or behind a link.
>
> For convenience, a corresponding API exists in `@coremedia/ckeditor5-link-common`. For use via a plugin, registering the `download` attribute may look as follows:
>
> ```typescript
> import Plugin from "@ckeditor/ckeditor5-core/src/plugin";
> import { getLinkAttributes, LinkAttributes } from "@coremedia/ckeditor5-link-common";
>
> export class LinkDownloadEditing extends Plugin {
>   static readonly pluginName: string = "LinkDownloadEditing";
>
>   static readonly requires = [LinkAttributes, /* ... */];
>
>   init(): void {
>     const { editor } = this;
>
>     getLinkAttributes(editor)?
>       .registerAttribute({ view: "download", model: "linkDownload" });
>   }
> }
> ```
>
> There is also a configuration level API, which you may use.
> - - - - -
