### PR TITLE
fix: Fix false mandatory EditorConfig Types

### DIFF
--- a/packages/ckeditor5-coremedia-richtext-support/src/augmentation.ts
+++ b/packages/ckeditor5-coremedia-richtext-support/src/augmentation.ts
@@ -12,7 +12,7 @@ declare module "@ckeditor/ckeditor5-core" {
      * if you do not want to get Markup cleaned up from elements or attributes
      * that are not supported in the editor instance.
      */
-    [COREMEDIA_RICHTEXT_SUPPORT_CONFIG_KEY]: CoreMediaRichTextSupportConfig;
+    [COREMEDIA_RICHTEXT_SUPPORT_CONFIG_KEY]?: CoreMediaRichTextSupportConfig;
   }
 
   interface PluginsMap {

--- a/packages/ckeditor5-coremedia-richtext/src/augmentation.ts
+++ b/packages/ckeditor5-coremedia-richtext/src/augmentation.ts
@@ -7,7 +7,7 @@ declare module "@ckeditor/ckeditor5-core" {
      * if you do not want to get Markup cleaned up from elements or attributes
      * that are not supported in the editor instance.
      */
-    [COREMEDIA_RICHTEXT_CONFIG_KEY]: CoreMediaRichTextConfig;
+    [COREMEDIA_RICHTEXT_CONFIG_KEY]?: CoreMediaRichTextConfig;
   }
 
   interface PluginsMap {

--- a/packages/ckeditor5-font-mapper/src/augmentation.ts
+++ b/packages/ckeditor5-font-mapper/src/augmentation.ts
@@ -2,7 +2,7 @@ import { type FontMapper, type FontMapperConfig, COREMEDIA_FONT_MAPPER_CONFIG_KE
 
 declare module "@ckeditor/ckeditor5-core" {
   interface EditorConfig {
-    [COREMEDIA_FONT_MAPPER_CONFIG_KEY]: FontMapperConfig;
+    [COREMEDIA_FONT_MAPPER_CONFIG_KEY]?: FontMapperConfig;
   }
 
   interface PluginsMap {


### PR DESCRIPTION
The EditorConfig type extensions in some of our augmentation files were marked as mandatory. This is false. TypeScript would complain about insufficient configs if these plugins were not configured. (Which is totally fine) Therefore, these config extensions are now marked as optional.

Cherry-picked from BBCode Branch, kudos to @pkliesch.