### PR TITLE
fix(core-common): Fix peerDependencies

### DIFF
--- a/packages/ckeditor5-core-common/package.json
+++ b/packages/ckeditor5-core-common/package.json
@@ -28,7 +28,7 @@
     "typescript": "^4.9.5"
   },
   "peerDependencies": {
-    "@ckeditor/ckeditor5-core": "^38.1.1"
+    "@ckeditor/ckeditor5-core": "^39.0.2"
   },
   "dependencies": {
     "@coremedia/ckeditor5-common": "15.0.2-rc.5",


### PR DESCRIPTION
Missed updating peerDependencies to 39.0.2 in ckeditor5-core-common.