### PR TITLE
Introduce A Façade For Setting And Getting Data (v2)

### DIFF
--- a/packages/ckeditor5-coremedia-example-data/src/data/ChallengingData.ts
+++ b/packages/ckeditor5-coremedia-example-data/src/data/ChallengingData.ts
@@ -1,0 +1,73 @@
+import { ExampleData } from "../ExampleData";
+import { h1, p, em, strong, richtext, h2, code } from "../RichText";
+
+const introduction = `${p(`\
+When it comes to detecting, if data need to be updated within an external \
+storage layer, there may be a challenge not to propagate semantically equal \
+data. This is at least true, if any update triggers subsequent processes, that \
+may be more or less expensive (think of publishing data, translating data, \
+etc.).\
+`)}\
+${p(`\
+To prevent such propagation in a flow setting data and subsequently getting \
+data, a plugin ${code("DataFacade")} exists, that will provide some \
+caching and may decide to forward the unchanged data instead to the \
+storage layer. This enables the storage layer by strict equivalence check just \
+to skip a given update.\
+`)}\
+`;
+
+const debuggingHint = `${p(`\
+If debug logging is activated, then you will see, that when choosing this \
+example, not the data retrieved from CKEditor 5 are forwarded to the storage \
+layer, but the cached data.\
+`)}\
+`;
+
+const elementOrder = `${h1("Challenge: Element Order")}\
+${introduction}\
+${p(`\
+This challenge is dedicated to element order: \
+It does not (really) matter, if the order of elements is \
+${code("&lt;em&gt;&lt;strong&gt;")} or \
+${code("&lt;strong&gt;&lt;em&gt;")}. \
+CKEditor 5 will prefer one of them when transforming the model state towards \
+the data layer.\
+`)}\
+${debuggingHint}\
+${h2("EM, STRONG")}\
+${p(`\
+${em(strong("em, strong"))}\
+`)}\
+${h2("STRONG, EM")}\
+${p(`\
+${strong(em("strong, em"))}\
+`)}\
+`;
+
+// noinspection HtmlUnknownAttribute
+const attributeOrder = `${h1("Challenge: Attribute Order")}\
+${introduction}\
+${p(`\
+This challenge is dedicated to attribute order: \
+It does not (really) matter, if the order of attributes is \
+${code("xlink:href")}, ${code("xlink:show")} or \
+${code("xlink:show")}, ${code("xlink:href")} . \
+CKEditor 5 will prefer one of them when transforming the model state towards \
+the data layer.\
+`)}\
+${debuggingHint}\
+${h2("HREF, SHOW")}\
+${p(`\
+<a xlink:href="https://example.org/" xlink:show="new">href, show</a>\
+`)}\
+${h2("SHOW, HREF")}\
+${p(`\
+<a xlink:show="new" xlink:href="https://example.org/">show, href</a>
+`)}\
+`;
+
+export const challengingData: ExampleData = {
+  "Challenge: Attribute Order": richtext(attributeOrder),
+  "Challenge: Element Order": richtext(elementOrder),
+};

--- a/packages/ckeditor5-data-facade/.eslintrc.js
+++ b/packages/ckeditor5-data-facade/.eslintrc.js
@@ -1,0 +1,12 @@
+module.exports = {
+  parser: "@typescript-eslint/parser",
+  overrides: [
+    {
+      files: ["**/*.ts", "**/*.tsx"],
+      parserOptions: {
+        tsconfigRootDir: __dirname,
+        project: "./tsconfig.json",
+      },
+    },
+  ],
+};

--- a/packages/ckeditor5-data-facade/README.md
+++ b/packages/ckeditor5-data-facade/README.md
@@ -1,0 +1,269 @@
+# Data Facade
+
+[![API Documentation][docs:api:badge]][docs:api]
+
+[docs:api]: <https://coremedia.github.io/ckeditor-plugins/docs/api/modules/ckeditor5_data_facade.html> "@coremedia/ckeditor5-data-facade"
+[docs:api:badge]: <https://img.shields.io/badge/docs-%F0%9F%93%83%20API-informational?style=for-the-badge>
+
+**Module:** `@coremedia/ckeditor5-data-facade`
+
+This module provides a way to prevent possibly unintended _normalization_ of
+data during a set/get data flow.
+
+In short, it ensures the following behavior, illustrated in pseudocode:
+
+```text
+newData = "<p>Hello Data Facade!</p>"
+
+setData(newData)
+currentData = getData()
+
+assert newData === currentData
+```
+
+## What is Normalization?
+
+Normalization starts, when, for example, providing options when getting data
+to trim these data.
+
+But also, CKEditor 5 does some normalization either implicitly or explicitly.
+
+### Explicit Normalization
+
+Unless you are making use of the _General HTML Support_ (GHS) feature,
+CKEditor 5 will strip any contents within the data, that cannot be controlled
+or created by corresponding commands.
+
+As an example, assume, you have not enabled the bold style. You will
+experience this behavior (pseudocode):
+
+```text
+newData = "<p>Hello <strong>World</strong>!</p>"
+
+setData(newData)
+currentData = getData()
+
+assert currentData === "<p>Hello World!</p>"
+```
+
+### Implicit Normalization
+
+There is also some normalization that is related to the representation of data
+within the CKEditor model layer. This layer provides no means, for example,
+to guarantee a given order of attributes.
+
+This behavior is perfectly fine for HTML representation, as there are various
+semantically equivalent ways to represent the data. For example, all the
+following are semantically equal, and it depends on the internal processing
+of CKEditor, which one is preferred.
+
+```text
+inputData = `<p class="C1 C2" lang="en">Hello!</p>`
+
+setData(inputData)
+currentData = getData()
+
+assert currentData in [
+  inputData,
+  `<p class="C2 C1" lang="en">Hello!</p>`,
+  `<p lang="en" class="C2 C1">Hello!</p>`,
+  `<p lang="en" class="C1 C2">Hello!</p>`,
+]
+```
+
+Thus, CKEditor may reorder attributes as well as attribute values, where
+applicable.
+
+## When to Use
+
+You should use this data facade when your external data storage, such as a
+CMS, does not expect a change of data in the scenario sketched above. More
+complex systems may trigger subsequent actions, that may be expensive, such as
+triggering a translation agency to translate the new data. In the context of
+CoreMedia CMS, such a change may trigger a so-called auto-checkout of a
+document, blocking any other editors from working on that document, although the
+current editor did not intend to apply any changes.
+
+## When Not to Use
+
+If it is intended, that CKEditor 5 performs normalization of data, and you want
+to store these normalized data immediately, you should stick to the standard
+patterns, such as using the `Autosave` plugin and directly getting and setting
+data at CKEditor.
+
+## Caveat
+
+Despite not normalizing just set data, the data facade and its underlying
+controller also ignore options on get (such as trimming). Only an optional
+set `rootName` is respected and is meant to provide the same behavior as for
+a multi-root editor.
+
+## Lazy CKEditor Initialization Support
+
+The data facade feature also comes with support for lazy CKEditor 5
+initialization, as it is typically used in CoreMedia Studio. 
+
+## Usage Options
+
+### Standalone Mode
+
+The standalone mode moves the data-control completely outside CKEditor 5. In
+this case, you will not add any related plugin (despite `Autosave` possibly).
+
+A typical setup may look as follows:
+
+```typescript
+import { DataFacadeController } from "@coremedia/ckeditor5-data-facade";
+
+const standaloneController = new DataFacadeController();
+
+// You may set (and get) data already now.
+standaloneController.setData("<p>Hello Standalone!</p>");
+
+await ClassicEditor
+  .create( document.querySelector( '#editor' ), {
+    plugins: [
+      Autosave,
+    ],
+    autosave: {
+      save() {
+        return saveData(standaloneController.getData());
+      },
+      waitingTime: 5000, 
+    },
+  })
+  .then( (editor) => {
+    // Inform controller, that editor is now available.
+    standaloneController.init(editor);
+  })
+  .catch( (error) => {
+    console.error( error );
+  } );
+
+// Will now either provide cached data or data directly provided by
+// CKEditor instance.
+standaloneController.getData();
+```
+
+### Embedded Mode
+
+If you do not require lazy initialization of CKEditor 5 instances, you can
+also use the embedded mode via data facade plugin.
+
+A typical setup may look as follows:
+
+```typescript
+import { DataFacade } from "@coremedia/ckeditor5-data-facade";
+
+ClassicEditor
+  .create( document.querySelector( '#editor' ), {
+    plugins: [
+      // Transitive Dependency on Autosave.
+      DataFacade,
+    ],
+    autosave: {
+      // no save needed
+       waitingTime: 5000, // in ms
+    },
+    dataFacade: {
+      save(controller) {
+        // saveData providing a promise to store data
+        // in an external data storage.
+        return saveData( controller.getData() );
+      },
+    }
+  })
+  .then( (editor) => {
+    editor.plugins.get(DataFacade).setData("<p>Hello Embedded!</p>");
+  })
+  .catch( (error) => {
+    console.error( error );
+  } );
+```
+
+### Mixed Mode aka Delegating Mode
+
+In mixed mode, you can combine lazy initialization and embedded mode. You
+just need to ensure to switch to delegating mode for the previous standalone
+controller during the initialization phase of the CKEditor instance.
+
+A typical setup may look as follows:
+
+```typescript
+import { DataFacade, DataFacadeController } from "@coremedia/ckeditor5-data-facade";
+
+const standaloneController = new DataFacadeController();
+
+// You may set (and get) data already now.
+standaloneController.setData("<p>Hello Standalone!</p>");
+
+ClassicEditor
+  .create( document.querySelector( '#editor' ), {
+    plugins: [
+      // Transitive Dependency on Autosave.
+      DataFacade,
+    ],
+    autosave: {
+      // no save needed
+       waitingTime: 5000, // in ms
+    },
+    dataFacade: {
+      save(controller) {
+        // saveData providing a promise to store data
+        // in an external data storage.
+        return saveData( controller.getData() );
+      }
+    }
+  })
+  .then( (editor) => {
+    // Will turn the controller into delegating mode.
+    standaloneController.init(editor);
+  })
+  .catch( (error) => {
+    console.error( error );
+  } );
+
+// Now the standalone controller delegates to the
+// embedded controller.
+standaloneController.setData("<p>Hello Delegating!</p>");
+```
+
+### Contextual Awareness Feature
+
+If you want to reduce the number of CKEditor 5 instances, as used, for example,
+in CoreMedia Studio Document Forms, you may reuse a given CKEditor 5 instance.
+We describe this as using the CKEditor 5 instance within a new context.
+
+To illustrate it even more, think of the CKEditor 5 previously bound to the
+text property of `document/1`. Now we switch to editing `document/2` and reuse
+the CKEditor 5 instance for the text property of that document. Due to
+asynchronous behavior, you may experience a data flow like this:
+
+```text
+const editor = CKEditor@42AC
+
+thread1: editor.setData(document1.text)
+thread2: editor.setData(document2.text)
+thread1: editor.getData()
+```
+
+Without further adaptations, `thread1` will now read the data of `document/2`
+and will not even be aware of it, possibly writing these data back to
+`document/1`.
+
+To provide some contextual awareness, you may provide context information that
+will signal any mismatched behavior. This context information is provided as
+an option to the corresponding methods. In pseudocode, it roughly looks like
+this, given the example above:
+
+```text
+const editor = CKEditor@42AC
+
+thread1: editor.setData(document1.text, { context: "document/1" })
+thread2: editor.setData(document2.text, { context: "document/2" })
+thread1: editor.getData({ context: "document/1" })
+```
+
+In this case, `getData` will throw a `ContextMismatchError`, which you may
+use to apply corresponding countermeasures, that at least should prevent the
+data of `document/2` to be written to `document/1`.

--- a/packages/ckeditor5-data-facade/__mocks__/@ckeditor/ckeditor5-autosave/autosave.ts
+++ b/packages/ckeditor5-data-facade/__mocks__/@ckeditor/ckeditor5-autosave/autosave.ts
@@ -1,0 +1,1 @@
+export class Autosave {}

--- a/packages/ckeditor5-data-facade/__mocks__/@ckeditor/ckeditor5-autosave/autosave.ts
+++ b/packages/ckeditor5-data-facade/__mocks__/@ckeditor/ckeditor5-autosave/autosave.ts
@@ -1,8 +1,17 @@
 export class Autosave {
   adapter?: AutosaveAdapter;
+  readonly editor: unknown;
+
+  constructor(editor: unknown) {
+    this.editor = editor;
+  }
 
   init(): void {
     // Nothing to do/to mock.
+  }
+
+  save(): Promise<unknown> {
+    return this.adapter?.save(this.editor) ?? Promise.resolve();
   }
 }
 

--- a/packages/ckeditor5-data-facade/__mocks__/@ckeditor/ckeditor5-autosave/autosave.ts
+++ b/packages/ckeditor5-data-facade/__mocks__/@ckeditor/ckeditor5-autosave/autosave.ts
@@ -1,1 +1,11 @@
-export class Autosave {}
+export class Autosave {
+  adapter?: AutosaveAdapter;
+
+  init(): void {
+    // Nothing to do/to mock.
+  }
+}
+
+export interface AutosaveAdapter {
+  save(editor: unknown): Promise<unknown>;
+}

--- a/packages/ckeditor5-data-facade/__mocks__/@ckeditor/ckeditor5-autosave/index.ts
+++ b/packages/ckeditor5-data-facade/__mocks__/@ckeditor/ckeditor5-autosave/index.ts
@@ -1,0 +1,1 @@
+export class Autosave {}

--- a/packages/ckeditor5-data-facade/__mocks__/@ckeditor/ckeditor5-autosave/index.ts
+++ b/packages/ckeditor5-data-facade/__mocks__/@ckeditor/ckeditor5-autosave/index.ts
@@ -1,1 +1,1 @@
-export class Autosave {}
+export { Autosave } from "./autosave";

--- a/packages/ckeditor5-data-facade/__mocks__/@ckeditor/ckeditor5-core/editor.ts
+++ b/packages/ckeditor5-data-facade/__mocks__/@ckeditor/ckeditor5-core/editor.ts
@@ -23,16 +23,16 @@ export abstract class Editor {
   readonly config;
   readonly #eventsOnce = new Map<string, () => void>();
 
-  protected constructor(config: Record<string, unknown | unknown[]>) {
+  protected constructor(config?: Record<string, unknown | unknown[]>) {
     // Config should exist first, so that plugins may already access it.
-    this.config = new Config(config);
+    this.config = new Config(config ?? {});
     this.plugins = new PluginCollection(this, config?.plugins as unknown[] | undefined);
     this.instanceId = Editor.#instanceCount++;
 
     let delayInit = false;
 
     // Some special mock behavior configuration.
-    if (config.hasOwnProperty("mock")) {
+    if (config?.hasOwnProperty("mock")) {
       const mockConfig = config.mock as MockConfig;
       if (mockConfig.initDelay) {
         delayInit = true;

--- a/packages/ckeditor5-data-facade/__mocks__/@ckeditor/ckeditor5-core/editor.ts
+++ b/packages/ckeditor5-data-facade/__mocks__/@ckeditor/ckeditor5-core/editor.ts
@@ -1,0 +1,22 @@
+import { PluginCollection } from "./plugincollection";
+import { DataController, Model } from "../ckeditor5-engine";
+import { Config } from "../ckeditor5-utils";
+
+export abstract class Editor {
+  static #instanceCount = 0;
+  readonly instanceId: number;
+  readonly plugins: PluginCollection;
+  readonly model = new Model();
+  readonly data = new DataController(this.model);
+  readonly config;
+
+  protected constructor(config: Record<string, unknown | unknown[]>) {
+    this.plugins = new PluginCollection(this, config?.plugins as unknown[] | undefined);
+    this.config = new Config(config);
+    this.instanceId = Editor.#instanceCount++;
+  }
+
+  toString(): string {
+    return `Editor@${this.instanceId}`;
+  }
+}

--- a/packages/ckeditor5-data-facade/__mocks__/@ckeditor/ckeditor5-core/editor.ts
+++ b/packages/ckeditor5-data-facade/__mocks__/@ckeditor/ckeditor5-core/editor.ts
@@ -9,11 +9,27 @@ export abstract class Editor {
   readonly model = new Model();
   readonly data = new DataController(this.model);
   readonly config;
+  readonly #eventsOnce = new Map<string, () => void>();
 
   protected constructor(config: Record<string, unknown | unknown[]>) {
-    this.plugins = new PluginCollection(this, config?.plugins as unknown[] | undefined);
+    // Config should exist first, so that plugins may already access it.
     this.config = new Config(config);
+    this.plugins = new PluginCollection(this, config?.plugins as unknown[] | undefined);
     this.instanceId = Editor.#instanceCount++;
+
+    this.plugins.mockInitAll();
+    this.fire("ready");
+  }
+
+  once(name: string, cb: () => void): void {
+    this.#eventsOnce.set(name, cb);
+  }
+
+  fire(name: string): void {
+    if (this.#eventsOnce.has(name)) {
+      this.#eventsOnce.get(name)?.();
+      this.#eventsOnce.delete(name);
+    }
   }
 
   toString(): string {

--- a/packages/ckeditor5-data-facade/__mocks__/@ckeditor/ckeditor5-core/editor.ts
+++ b/packages/ckeditor5-data-facade/__mocks__/@ckeditor/ckeditor5-core/editor.ts
@@ -2,6 +2,18 @@ import { PluginCollection } from "./plugincollection";
 import { DataController, Model } from "../ckeditor5-engine";
 import { Config } from "../ckeditor5-utils";
 
+/**
+ * Some extra configuration you may apply to control mocking behavior.
+ * Will be passed with "mock" configuration key.
+ */
+interface MockConfig {
+  /**
+   * If given, will delay the initialization of plugins and subsequent
+   * `"ready"` event until the provided promise got resolved.
+   */
+  initDelay?: Promise<void>;
+}
+
 export abstract class Editor {
   static #instanceCount = 0;
   readonly instanceId: number;
@@ -17,6 +29,24 @@ export abstract class Editor {
     this.plugins = new PluginCollection(this, config?.plugins as unknown[] | undefined);
     this.instanceId = Editor.#instanceCount++;
 
+    let delayInit = false;
+
+    // Some special mock behavior configuration.
+    if (config.hasOwnProperty("mock")) {
+      const mockConfig = config.mock as MockConfig;
+      if (mockConfig.initDelay) {
+        delayInit = true;
+        // Let init be controlled from within the test.
+        void mockConfig.initDelay.then(() => this.mockInit());
+      }
+    }
+
+    if (!delayInit) {
+      this.mockInit();
+    }
+  }
+
+  mockInit(): void {
     this.plugins.mockInitAll();
     this.fire("ready");
   }

--- a/packages/ckeditor5-data-facade/__mocks__/@ckeditor/ckeditor5-core/index.ts
+++ b/packages/ckeditor5-data-facade/__mocks__/@ckeditor/ckeditor5-core/index.ts
@@ -1,0 +1,5 @@
+export { Editor } from "./editor";
+
+export { PluginCollection } from "./plugincollection";
+
+export { Plugin } from "./plugin";

--- a/packages/ckeditor5-data-facade/__mocks__/@ckeditor/ckeditor5-core/plugin.ts
+++ b/packages/ckeditor5-data-facade/__mocks__/@ckeditor/ckeditor5-core/plugin.ts
@@ -1,0 +1,1 @@
+export class Plugin {}

--- a/packages/ckeditor5-data-facade/__mocks__/@ckeditor/ckeditor5-core/plugin.ts
+++ b/packages/ckeditor5-data-facade/__mocks__/@ckeditor/ckeditor5-core/plugin.ts
@@ -1,1 +1,7 @@
-export class Plugin {}
+export class Plugin {
+  readonly editor: unknown;
+
+  constructor(editor: unknown) {
+    this.editor = editor;
+  }
+}

--- a/packages/ckeditor5-data-facade/__mocks__/@ckeditor/ckeditor5-core/plugincollection.ts
+++ b/packages/ckeditor5-data-facade/__mocks__/@ckeditor/ckeditor5-core/plugincollection.ts
@@ -37,7 +37,7 @@ export class PluginCollection {
             return this.#dataFacade;
           case "Autosave":
             if (!this.#autosave) {
-              this.#autosave = new Autosave();
+              this.#autosave = new Autosave(this.#context);
             }
             return this.#autosave;
           default:

--- a/packages/ckeditor5-data-facade/__mocks__/@ckeditor/ckeditor5-core/plugincollection.ts
+++ b/packages/ckeditor5-data-facade/__mocks__/@ckeditor/ckeditor5-core/plugincollection.ts
@@ -1,0 +1,37 @@
+import { DataFacade } from "../../../src";
+import { Editor } from "@ckeditor/ckeditor5-core";
+
+export class PluginCollection {
+  readonly #context: unknown;
+  readonly #plugins: unknown[];
+  #dataFacade?: DataFacade;
+
+  constructor(context: unknown, availablePlugins: unknown[] = []) {
+    this.#context = context;
+    this.#plugins = availablePlugins;
+  }
+
+  has(key: unknown): boolean {
+    return this.#plugins.includes(key);
+  }
+
+  get(key: unknown): unknown {
+    if (this.has(key)) {
+      if (typeof key === "function") {
+        switch (key.name) {
+          case "DataFacade":
+            // Lazy initialization required, as at construction time, relevant
+            // setup in the editor (here: config) may not be available, yet.
+            if (!this.#dataFacade) {
+              this.#dataFacade = new DataFacade(this.#context as Editor);
+            }
+            return this.#dataFacade;
+          default:
+            throw new Error(`Don't know how to provide instance of: "${key.name}"`);
+        }
+      }
+      throw new Error(`get: Mock does not know how to get instance for: "${key}.`);
+    }
+    throw new Error(`get: No Plugin registered for key "${key}.`);
+  }
+}

--- a/packages/ckeditor5-data-facade/__mocks__/@ckeditor/ckeditor5-core/plugincollection.ts
+++ b/packages/ckeditor5-data-facade/__mocks__/@ckeditor/ckeditor5-core/plugincollection.ts
@@ -1,14 +1,23 @@
 import { DataFacade } from "../../../src";
 import { Editor } from "@ckeditor/ckeditor5-core";
+import { Autosave } from "../ckeditor5-autosave";
 
 export class PluginCollection {
   readonly #context: unknown;
   readonly #plugins: unknown[];
   #dataFacade?: DataFacade;
+  #autosave?: Autosave;
 
   constructor(context: unknown, availablePlugins: unknown[] = []) {
     this.#context = context;
     this.#plugins = availablePlugins;
+  }
+
+  mockInitAll() {
+    for (const pluginKey of this.#plugins) {
+      const plugin = this.get(pluginKey) as { init?: () => void };
+      plugin.init?.();
+    }
   }
 
   has(key: unknown): boolean {
@@ -18,20 +27,25 @@ export class PluginCollection {
   get(key: unknown): unknown {
     if (this.has(key)) {
       if (typeof key === "function") {
+        // Lazy initialization required, as at construction time, relevant
+        // setup in the editor (here: config) may not be available, yet.
         switch (key.name) {
           case "DataFacade":
-            // Lazy initialization required, as at construction time, relevant
-            // setup in the editor (here: config) may not be available, yet.
             if (!this.#dataFacade) {
               this.#dataFacade = new DataFacade(this.#context as Editor);
             }
             return this.#dataFacade;
+          case "Autosave":
+            if (!this.#autosave) {
+              this.#autosave = new Autosave();
+            }
+            return this.#autosave;
           default:
             throw new Error(`Don't know how to provide instance of: "${key.name}"`);
         }
       }
       throw new Error(`get: Mock does not know how to get instance for: "${key}.`);
     }
-    throw new Error(`get: No Plugin registered for key "${key}.`);
+    throw new Error(`get: No Plugin registered for key "${key}" (${typeof key}).`);
   }
 }

--- a/packages/ckeditor5-data-facade/__mocks__/@ckeditor/ckeditor5-core/plugincollection.ts
+++ b/packages/ckeditor5-data-facade/__mocks__/@ckeditor/ckeditor5-core/plugincollection.ts
@@ -2,6 +2,35 @@ import { DataFacade } from "../../../src";
 import { Editor } from "@ckeditor/ckeditor5-core";
 import { Autosave } from "../ckeditor5-autosave";
 
+const byStringKey = (key: string, plugin: unknown): boolean => {
+  if (typeof plugin === "function") {
+    return plugin.name === key;
+  }
+  console.debug(`Signal not found searching for ${key} for entry: ${plugin} (${typeof plugin})`);
+  return false;
+};
+
+const byConstructor = (key: unknown, plugin: unknown): boolean => {
+  if (typeof plugin === "function") {
+    return key === plugin;
+  }
+  console.debug(`Signal not found searching for ${key} for entry: ${plugin} (${typeof plugin})`);
+  return false;
+};
+
+const pluginPredicate =
+  (key: unknown) =>
+  (plugin: unknown): boolean => {
+    if (typeof key === "string") {
+      return byStringKey(key, plugin);
+    }
+    if (typeof key === "function") {
+      return byConstructor(key, plugin);
+    }
+    console.debug(`Unsupported key ${key} of type ${typeof key}. Will signal: Not found.`);
+    return false;
+  };
+
 export class PluginCollection {
   readonly #context: unknown;
   readonly #plugins: unknown[];
@@ -21,31 +50,34 @@ export class PluginCollection {
   }
 
   has(key: unknown): boolean {
-    return this.#plugins.includes(key);
+    return this.#plugins.some(pluginPredicate(key));
   }
 
   get(key: unknown): unknown {
-    if (this.has(key)) {
-      if (typeof key === "function") {
-        // Lazy initialization required, as at construction time, relevant
-        // setup in the editor (here: config) may not be available, yet.
-        switch (key.name) {
-          case "DataFacade":
-            if (!this.#dataFacade) {
-              this.#dataFacade = new DataFacade(this.#context as Editor);
-            }
-            return this.#dataFacade;
-          case "Autosave":
-            if (!this.#autosave) {
-              this.#autosave = new Autosave(this.#context);
-            }
-            return this.#autosave;
-          default:
-            throw new Error(`Don't know how to provide instance of: "${key.name}"`);
-        }
-      }
-      throw new Error(`get: Mock does not know how to get instance for: "${key}.`);
+    const plugin = this.#plugins.find(pluginPredicate(key));
+
+    if (!plugin) {
+      throw new Error(`get: No Plugin registered for key "${key}" (${typeof key}).`);
     }
-    throw new Error(`get: No Plugin registered for key "${key}" (${typeof key}).`);
+
+    if (typeof plugin === "function") {
+      // Lazy initialization required, as at construction time, relevant
+      // setup in the editor (here: config) may not be available, yet.
+      switch (plugin.name) {
+        case "DataFacade":
+          if (!this.#dataFacade) {
+            this.#dataFacade = new DataFacade(this.#context as Editor);
+          }
+          return this.#dataFacade;
+        case "Autosave":
+          if (!this.#autosave) {
+            this.#autosave = new Autosave(this.#context);
+          }
+          return this.#autosave;
+        default:
+          throw new Error(`Don't know how to provide instance of: "${plugin.name}"`);
+      }
+    }
+    throw new Error(`get: Mock does not know how to get instance for: "${typeof plugin}".`);
   }
 }

--- a/packages/ckeditor5-data-facade/__mocks__/@ckeditor/ckeditor5-engine/controller/datacontroller.ts
+++ b/packages/ckeditor5-data-facade/__mocks__/@ckeditor/ckeditor5-engine/controller/datacontroller.ts
@@ -1,0 +1,40 @@
+import { Model } from "../model/model";
+
+export class DataController {
+  #data: string | Record<string, string> = "";
+  #options: object = {};
+
+  readonly model;
+
+  constructor(model: Model) {
+    this.model = model;
+  }
+
+  set(data: string | Record<string, string>, options: object = {}): void {
+    this.#data = data;
+    this.#options = options;
+    this.model.document.version++;
+  }
+
+  get(
+    options: {
+      rootName?: string;
+      trim?: "empty" | "none";
+    } = {},
+  ): string {
+    const { rootName = "main", trim = "empty" } = options;
+    const data = this.#data;
+
+    if (typeof data === "string") {
+      if (rootName === "main") {
+        return trim === "none" ? data : data.trim();
+      }
+      throw new Error(`MockError: Unsupported rootName ${rootName} for string data.`);
+    }
+    if (data.hasOwnProperty(rootName)) {
+      const rootData = data[rootName];
+      return trim === "none" ? rootData : rootData.trim();
+    }
+    throw new Error(`MockError: No data available for rootName ${rootName}.`);
+  }
+}

--- a/packages/ckeditor5-data-facade/__mocks__/@ckeditor/ckeditor5-engine/index.ts
+++ b/packages/ckeditor5-data-facade/__mocks__/@ckeditor/ckeditor5-engine/index.ts
@@ -1,0 +1,3 @@
+export { DataController } from "./controller/datacontroller";
+export { Document } from "./model/document";
+export { Model } from "./model/model";

--- a/packages/ckeditor5-data-facade/__mocks__/@ckeditor/ckeditor5-engine/model/document.ts
+++ b/packages/ckeditor5-data-facade/__mocks__/@ckeditor/ckeditor5-engine/model/document.ts
@@ -1,0 +1,4 @@
+export class Document {
+  // see model.history: starts with 0
+  version = 0;
+}

--- a/packages/ckeditor5-data-facade/__mocks__/@ckeditor/ckeditor5-engine/model/model.ts
+++ b/packages/ckeditor5-data-facade/__mocks__/@ckeditor/ckeditor5-engine/model/model.ts
@@ -1,0 +1,5 @@
+import { Document } from "./document";
+
+export class Model {
+  readonly document = new Document();
+}

--- a/packages/ckeditor5-data-facade/__mocks__/@ckeditor/ckeditor5-ui/editorui/editorui.ts
+++ b/packages/ckeditor5-data-facade/__mocks__/@ckeditor/ckeditor5-ui/editorui/editorui.ts
@@ -1,0 +1,1 @@
+export abstract class EditorUI {}

--- a/packages/ckeditor5-data-facade/__mocks__/@ckeditor/ckeditor5-ui/editorui/editorui.ts
+++ b/packages/ckeditor5-data-facade/__mocks__/@ckeditor/ckeditor5-ui/editorui/editorui.ts
@@ -1,1 +1,2 @@
+// eslint-disable-next-line @typescript-eslint/no-extraneous-class
 export abstract class EditorUI {}

--- a/packages/ckeditor5-data-facade/__mocks__/@ckeditor/ckeditor5-ui/index.ts
+++ b/packages/ckeditor5-data-facade/__mocks__/@ckeditor/ckeditor5-ui/index.ts
@@ -1,0 +1,1 @@
+export { EditorUI } from "./editorui/editorui";

--- a/packages/ckeditor5-data-facade/__mocks__/@ckeditor/ckeditor5-utils/config.ts
+++ b/packages/ckeditor5-data-facade/__mocks__/@ckeditor/ckeditor5-utils/config.ts
@@ -1,0 +1,11 @@
+export class Config {
+  readonly #config: Record<string, unknown>;
+
+  constructor(config: Record<string, unknown>) {
+    this.#config = config;
+  }
+
+  get(name: string): unknown | undefined {
+    return this.#config[name];
+  }
+}

--- a/packages/ckeditor5-data-facade/__mocks__/@ckeditor/ckeditor5-utils/config.ts
+++ b/packages/ckeditor5-data-facade/__mocks__/@ckeditor/ckeditor5-utils/config.ts
@@ -1,7 +1,7 @@
 export class Config {
   readonly #config: Record<string, unknown>;
 
-  constructor(config: Record<string, unknown>) {
+  constructor(config: Record<string, unknown> = {}) {
     this.#config = config;
   }
 

--- a/packages/ckeditor5-data-facade/__mocks__/@ckeditor/ckeditor5-utils/index.ts
+++ b/packages/ckeditor5-data-facade/__mocks__/@ckeditor/ckeditor5-utils/index.ts
@@ -1,0 +1,1 @@
+export { Config } from "./config";

--- a/packages/ckeditor5-data-facade/__tests__/ContextMismatchError.test.ts
+++ b/packages/ckeditor5-data-facade/__tests__/ContextMismatchError.test.ts
@@ -1,0 +1,51 @@
+import { ContextMismatchError } from "../src/ContextMismatchError";
+
+describe("ContextMismatchError", () => {
+  it("should be possible to instantiate the error without a message", () => {
+    const error = new ContextMismatchError();
+    expect(error).toHaveProperty("message", "");
+  });
+
+  it("should be possible to instantiate the error with a message", () => {
+    const msg = "Lorem Ipsum";
+    const error = new ContextMismatchError(msg);
+    expect(error).toHaveProperty("message", msg);
+  });
+
+  it("should be possible to instantiate the error with a actual context", () => {
+    const msg = "Lorem Ipsum";
+    const actual = "actual";
+    const contextInformation = {
+      actual,
+    };
+    const error = new ContextMismatchError(msg, contextInformation);
+    expect(error).toHaveProperty("message", msg);
+    expect(error).toHaveProperty("actual", actual);
+  });
+
+  it("should be possible to instantiate the error with a expected context", () => {
+    const msg = "Lorem Ipsum";
+    const expected = "expected";
+    const contextInformation = {
+      expected,
+    };
+    const error = new ContextMismatchError(msg, contextInformation);
+    expect(error).toHaveProperty("message", msg);
+    expect(error).toHaveProperty("expected", expected);
+  });
+
+  it("should be possible to instantiate the error with both actual and expected context", () => {
+    const msg = "Lorem Ipsum";
+    const actual = "actual";
+    const expected = "expected";
+    const contextInformation = {
+      actual,
+      expected,
+    };
+    const error = new ContextMismatchError(msg, contextInformation);
+
+    expect(error).toHaveProperty("message", msg);
+    expect(error).toHaveProperty("actual", actual);
+    expect(error).toHaveProperty("expected", expected);
+  });
+});

--- a/packages/ckeditor5-data-facade/__tests__/DataFacade.test.ts
+++ b/packages/ckeditor5-data-facade/__tests__/DataFacade.test.ts
@@ -1,0 +1,119 @@
+import { Editor } from "@ckeditor/ckeditor5-core";
+import type { EditorUI } from "@ckeditor/ckeditor5-ui";
+import { Autosave } from "@ckeditor/ckeditor5-autosave";
+import { DataFacade, SetDataData } from "../src";
+
+jest.mock("@ckeditor/ckeditor5-core");
+
+class DummyEditor extends Editor {
+  readonly ui: EditorUI = {} as EditorUI;
+
+  /**
+   * Simulates an internal change to the data (like reordering attributes).
+   * Similar to setting data, but skipping version update.
+   * @param data - data to set to be _equal_ to the original set data
+   */
+  simulateDataReformat(data: SetDataData): void {
+    const previousVersion = this.model.document.version;
+    this.data.set(data);
+    this.model.document.version = previousVersion;
+  }
+
+  /**
+   * Make test more verbose (we could have invoked data controller directly).
+   *
+   * @param data - data that are the result of editorial changes
+   */
+  simulateEditorialUpdate(data: SetDataData): void {
+    this.data.set(data);
+  }
+}
+
+describe("DataFacade", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should forward previously set data once initialized", async () => {
+    const dataFixture = "DATA";
+    const initDelay = new Promise<void>((resolve) => window.setTimeout(resolve, 1));
+
+    const editor = new DummyEditor({
+      plugins: [DataFacade, Autosave],
+      // @ts-expect-error – Just some mock configuration.
+      mock: {
+        initDelay,
+      },
+    });
+
+    const dataFacade = editor.plugins.get(DataFacade);
+    // This will also forward the data to the editor, but we will not know
+    // if the editor itself does not override these afterward, e.g., when
+    // reading the `initialData` property.
+    dataFacade.setData(dataFixture);
+
+    editor.data.set("mocking data set from initialData");
+
+    expect.assertions(2);
+
+    await initDelay.then(() => {
+      // After init is done, data should have been forwarded.
+      expect(editor.data.get()).toEqual(dataFixture);
+
+      // Caching should work.
+      editor.simulateDataReformat(dataFixture.toLowerCase());
+      expect(dataFacade.getData()).toEqual(dataFixture);
+    });
+  });
+
+  describe("Autosave integration", () => {
+    const dataFixture = "DATA";
+    let savedData = "";
+    let editor: DummyEditor;
+    let autosave: Autosave;
+    let dataFacade: DataFacade;
+
+    beforeEach(() => {
+      editor = new DummyEditor({
+        plugins: [DataFacade, Autosave],
+        dataFacade: {
+          save(dataApi): Promise<void> {
+            savedData = dataApi.getData();
+            return Promise.resolve();
+          },
+        },
+      });
+
+      autosave = editor.plugins.get(Autosave);
+      dataFacade = editor.plugins.get(DataFacade);
+    });
+
+    it("should hook into autosave and use custom configuration for saving cached data", async () => {
+      dataFacade.setData(dataFixture);
+
+      editor.simulateDataReformat(dataFixture.toLowerCase());
+
+      expect.assertions(1);
+
+      // We do not mock auto-forwarding set data to Autosave. Thus, invoking
+      // it explicitly.
+      await autosave.save().then(() => {
+        expect(savedData).toEqual(dataFixture);
+      });
+    });
+
+    it("should hook into autosave but prefer editorial changes on data facade's save", async () => {
+      dataFacade.setData(dataFixture);
+
+      editor.simulateEditorialUpdate(dataFixture.toLowerCase());
+
+      expect.assertions(1);
+
+      // We do not mock auto-forwarding set data to Autosave. Thus, invoking
+      // it explicitly.
+      await autosave.save().then(() => {
+        expect(savedData).toEqual(dataFixture.toLowerCase());
+      });
+    });
+  });
+});

--- a/packages/ckeditor5-data-facade/__tests__/DataFacadeController.test.ts
+++ b/packages/ckeditor5-data-facade/__tests__/DataFacadeController.test.ts
@@ -2,6 +2,7 @@ import { ContextMismatchError, DataFacade, DataFacadeController, SetDataData } f
 import { Editor } from "@ckeditor/ckeditor5-core";
 import type { EditorUI } from "@ckeditor/ckeditor5-ui";
 import { CKEditorError } from "@ckeditor/ckeditor5-utils";
+import { Autosave } from "@ckeditor/ckeditor5-autosave";
 
 jest.mock("@ckeditor/ckeditor5-core");
 
@@ -41,7 +42,9 @@ describe("DataFacadeController", () => {
       const dataFixture = "DATA";
       const controller = new DataFacadeController();
       const editor = new DummyEditor({
-        plugins: [DataFacade],
+        // We manually need to add Autosave, as we did not mock resolving
+        // required plugins.
+        plugins: [DataFacade, Autosave],
       });
       const dataFacade = editor.plugins.get(DataFacade);
 
@@ -65,7 +68,9 @@ describe("DataFacadeController", () => {
       const dataFixture = "DATA";
       const controller = new DataFacadeController();
       const editor = new DummyEditor({
-        plugins: [DataFacade],
+        // We manually need to add Autosave, as we did not mock resolving
+        // required plugins.
+        plugins: [DataFacade, Autosave],
       });
       const dataFacade = editor.plugins.get(DataFacade);
 
@@ -89,7 +94,9 @@ describe("DataFacadeController", () => {
       const dataFixture = "DATA";
       const controller = new DataFacadeController();
       const editor = new DummyEditor({
-        plugins: [DataFacade],
+        // We manually need to add Autosave, as we did not mock resolving
+        // required plugins.
+        plugins: [DataFacade, Autosave],
       });
       const dataFacade = editor.plugins.get(DataFacade);
 

--- a/packages/ckeditor5-data-facade/__tests__/DataFacadeController.test.ts
+++ b/packages/ckeditor5-data-facade/__tests__/DataFacadeController.test.ts
@@ -1,0 +1,409 @@
+import { ContextMismatchError, DataFacade, DataFacadeController, SetDataData } from "../src";
+import { Editor } from "@ckeditor/ckeditor5-core";
+import type { EditorUI } from "@ckeditor/ckeditor5-ui";
+import { CKEditorError } from "@ckeditor/ckeditor5-utils";
+
+jest.mock("@ckeditor/ckeditor5-core");
+
+class DummyEditor extends Editor {
+  readonly ui: EditorUI = {} as EditorUI;
+
+  /**
+   * Simulates an internal change to the data (like reordering attributes).
+   * Similar to setting data, but skipping version update.
+   * @param data - data to set to be _equal_ to the original set data
+   */
+  simulateDataReformat(data: SetDataData): void {
+    const previousVersion = this.model.document.version;
+    this.data.set(data);
+    this.model.document.version = previousVersion;
+  }
+
+  /**
+   * Make test more verbose (we could have invoked data controller directly).
+   *
+   * @param data - data that are the result of editorial changes
+   */
+  simulateEditorialUpdate(data: SetDataData): void {
+    this.data.set(data);
+  }
+}
+
+describe("DataFacadeController", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // ========================================================[ Delegating Mode ]
+
+  describe("Delegating Mode", () => {
+    it("should retrieve data from delegate controller when in delegating mode", () => {
+      const dataFixture = "DATA";
+      const controller = new DataFacadeController();
+      const editor = new DummyEditor({
+        plugins: [DataFacade],
+      });
+      const dataFacade = editor.plugins.get(DataFacade);
+
+      controller.init(editor);
+
+      expect(controller).toHaveProperty("delegating", true);
+
+      dataFacade.setData(dataFixture);
+      editor.simulateDataReformat(dataFixture.toLowerCase());
+
+      // Theoretically, without delegating enabled, the subsequent get should
+      // directly forward to editor (no data yet cached in the original
+      // controller).
+      //
+      // Thus, because we now get the cached data, we know that it is from
+      // the data-controller we delegate to.
+      expect(controller.getData()).toEqual(dataFixture);
+    });
+
+    it("should propagate data to delegate and editor subsequently when delegation gets initialized", () => {
+      const dataFixture = "DATA";
+      const controller = new DataFacadeController();
+      const editor = new DummyEditor({
+        plugins: [DataFacade],
+      });
+      const dataFacade = editor.plugins.get(DataFacade);
+
+      controller.setData(dataFixture);
+
+      controller.init(editor);
+
+      expect(controller).toHaveProperty("delegating", true);
+
+      // Should have propagated on init to delegate data-facade-controller and
+      // to editor subsequently.
+      expect(dataFacade.getData()).toEqual(dataFixture);
+      expect(editor.data.get()).toEqual(dataFixture);
+
+      // Some additional check, that delegation also respects caching now.
+      editor.simulateDataReformat(dataFixture.toLowerCase());
+      expect(dataFacade.getData()).toEqual(dataFixture);
+    });
+
+    it("should forward data set to delegate directly", () => {
+      const dataFixture = "DATA";
+      const controller = new DataFacadeController();
+      const editor = new DummyEditor({
+        plugins: [DataFacade],
+      });
+      const dataFacade = editor.plugins.get(DataFacade);
+
+      controller.init(editor);
+
+      expect(controller).toHaveProperty("delegating", true);
+
+      // Should be forwarded to delegate.
+      controller.setData(dataFixture);
+
+      // Should have propagated to delegate data-facade-controller and
+      // to editor subsequently.
+      expect(dataFacade.getData()).toEqual(dataFixture);
+      expect(editor.data.get()).toEqual(dataFixture);
+    });
+  });
+
+  // ========================================================[ Standalone Mode ]
+
+  describe("Standalone Mode", () => {
+    // ----------------------------------------------------------[ Constructor ]
+
+    describe("constructor", () => {
+      it("should be possible creating an instance without editor reference", () => {
+        const controller = new DataFacadeController();
+        expect(controller).toHaveProperty("editor", undefined);
+      });
+    });
+
+    // -----------------------------------------------------------------[ Init ]
+
+    describe("init", () => {
+      it("should be possible to bind to editor even without DataFacade plugin installed", () => {
+        const controller = new DataFacadeController();
+        const editor = new DummyEditor();
+        controller.init(editor);
+        expect(controller).toHaveProperty("editor", editor);
+      });
+
+      it("should propagate any already set data", () => {
+        const dataFixture = "DATA";
+        const controller = new DataFacadeController();
+        const editor = new DummyEditor();
+
+        controller.setData(dataFixture);
+
+        controller.init(editor);
+        expect(editor.data.get()).toEqual(dataFixture);
+      });
+    });
+
+    // ------------------------------------------------------[ getData/setData ]
+
+    describe("getData/setData", () => {
+      describe("General Use Cases", () => {
+        it("should cache data if not bound to editor instance already", () => {
+          const dataFixture = "DATA";
+          const controller = new DataFacadeController();
+
+          controller.setData(dataFixture);
+
+          expect(controller.getData()).toEqual(dataFixture);
+        });
+
+        it("should propagate data set if bound to editor instance", () => {
+          const dataFixture = "DATA";
+          const editor = new DummyEditor();
+          const controller = new DataFacadeController(editor);
+
+          controller.setData(dataFixture);
+
+          expect(controller.getData()).toEqual(dataFixture);
+          expect(editor.data.get()).toEqual(dataFixture);
+        });
+
+        it("should read data directly, if none cached", () => {
+          const dataFixture = "DATA";
+          const editor = new DummyEditor();
+          const controller = new DataFacadeController(editor);
+
+          // Similar to: There was some other way, that provided the initial data.
+          editor.simulateEditorialUpdate(dataFixture);
+
+          expect(controller.getData()).toEqual(dataFixture);
+          expect(editor.data.get()).toEqual(dataFixture);
+        });
+
+        describe("Options on get support", () => {
+          it.each`
+            trim       | data        | expected
+            ${"empty"} | ${" DATA "} | ${" DATA "}
+            ${"none"}  | ${" DATA "} | ${" DATA "}
+          `(
+            "[$#] should ignore options in bound mode but without editorial actions applied (trim = $trim)",
+            ({ trim, data, expected }: { trim: "empty" | "none"; data: string; expected: string }) => {
+              const editor = new DummyEditor();
+              const controller = new DataFacadeController(editor);
+
+              controller.setData(data);
+
+              expect(controller.getData({ trim })).toEqual(expected);
+            },
+          );
+
+          it.each`
+            trim       | data        | expected
+            ${"empty"} | ${" DATA "} | ${"DATA"}
+            ${"none"}  | ${" DATA "} | ${" DATA "}
+          `(
+            "[$#] should forward options in bound mode when editorial changes got applied (trim = $trim)",
+            ({ trim, data, expected }: { trim: "empty" | "none"; data: string; expected: string }) => {
+              const dataSet = "originalData";
+              const editor = new DummyEditor();
+              const controller = new DataFacadeController(editor);
+
+              controller.setData(dataSet);
+
+              editor.simulateEditorialUpdate(data);
+
+              expect(controller.getData({ trim })).toEqual(expected);
+            },
+          );
+        });
+
+        describe("Multi-Root Support", () => {
+          it("should respect available rootName in unbound mode", () => {
+            const dataFixture = "DATA";
+            const rootName = "ROOT";
+            const controller = new DataFacadeController();
+
+            controller.setData({ [rootName]: dataFixture });
+            expect(controller.getData({ rootName })).toEqual(dataFixture);
+          });
+
+          /**
+           * Here is some design space: Is it ok, to simulate the failure "early"
+           * here, although we cannot know yet for sure, if a given root is
+           * unavailable?
+           *
+           * In the example below, where no data has been cached yet, we took
+           * the offensive approach, by possibly triggering a failure late
+           * on initialization (binding to editor), only. We decided this way,
+           * as in that case, we do not have any hints available on existing
+           * root names.
+           *
+           * Here, when we already have some data cached, we may provide a
+           * rough guess if a `rootName` is available later. That is why
+           * we decided to follow a fail-early approach.
+           *
+           * This decision may/should be revisited once we actively use
+           * multi-root-editing.
+           */
+          it("should simulate data retrieval failure on unavailable rootName in cache", () => {
+            const dataFixture = "DATA";
+            const rootName = "ROOT";
+            const controller = new DataFacadeController();
+            const callToFail = () => controller.getData({ rootName });
+
+            // Will set data for rootName = main.
+            controller.setData(dataFixture);
+
+            expect(callToFail).toThrow(CKEditorError);
+          });
+
+          /**
+           * Here is some design space: What to do, when no data have been set
+           * yet and no editor bound yet, when trying to get data for some
+           * yet unknown `rootName`?
+           *
+           * We could simulate a failure. But as we do not know if the
+           * editor would know such a `rootName`, we may as well decide not
+           * to fail early – which again would mean that we may have a
+           * failure later on initialization.
+           *
+           * We decided for the latter, mostly because the code path is easier
+           * to follow and can skip some nested if-statements.
+           *
+           * This decision may/should be revisited once we actively use
+           * multi-root-editing.
+           */
+          it("should not fail on unavailable rootName but empty cache", () => {
+            const rootName = "ROOT";
+            const controller = new DataFacadeController();
+            const callToFail = () => controller.getData({ rootName });
+
+            expect(callToFail).not.toThrow(CKEditorError);
+          });
+        });
+      });
+
+      describe("Main Use Cases", () => {
+        it("should prefer original data on no editorial change (main use case)", () => {
+          const dataFixture = "DATA";
+          const internallyNormalizedData = dataFixture.toLowerCase();
+          const editor = new DummyEditor();
+          const controller = new DataFacadeController(editor);
+
+          controller.setData(dataFixture);
+
+          editor.simulateDataReformat(internallyNormalizedData);
+
+          // Precondition check that our simulated change works.
+          expect(editor.data.get()).toEqual(internallyNormalizedData);
+
+          // No version change? Provide the original data.
+          expect(controller.getData()).toEqual(dataFixture);
+        });
+
+        it("should prefer data as result from editing (main use case)", () => {
+          const dataFixture = "DATA";
+          const editorialData = dataFixture.toLowerCase();
+          const editor = new DummyEditor();
+          const controller = new DataFacadeController(editor);
+
+          controller.setData(dataFixture);
+
+          editor.simulateEditorialUpdate(editorialData);
+
+          // Precondition check that our simulated change works.
+          expect(editor.data.get()).toEqual(editorialData);
+
+          // Version change? Must not provide data originally set via data facade
+          // controller.
+          expect(controller.getData()).toEqual(editorialData);
+        });
+      });
+
+      describe("Feature: Context Awareness", () => {
+        describe.each`
+          editorBinding
+          ${"unbound"}
+          ${"bound"}
+        `("[$#] Editor Binding: $editorBinding", ({ editorBinding }: { editorBinding: "unbound" | "bound" }) => {
+          let editor: DummyEditor | undefined;
+
+          beforeEach(() => {
+            if (editorBinding === "bound") {
+              editor = new DummyEditor();
+            }
+          });
+
+          it("should provide data on context match", () => {
+            const dataFixture = "DATA";
+            const contextOnSet = "document/1";
+            const contextOnGet = contextOnSet;
+            const controller = new DataFacadeController(editor);
+
+            controller.setData(dataFixture, { context: contextOnSet });
+
+            expect(controller.getData({ context: contextOnGet })).toEqual(dataFixture);
+          });
+
+          it("should fail providing data if not specified when setting data", () => {
+            const dataFixture = "DATA";
+            const contextOnGet = "document/1";
+            const controller = new DataFacadeController(editor);
+
+            controller.setData(dataFixture);
+
+            expect(() => controller.getData({ context: contextOnGet })).toThrow(ContextMismatchError);
+          });
+
+          it("should fail providing data if not specified when getting data", () => {
+            const dataFixture = "DATA";
+            const contextOnSet = "document/1";
+            const controller = new DataFacadeController(editor);
+
+            controller.setData(dataFixture, { context: contextOnSet });
+
+            expect(() => controller.getData()).toThrow(ContextMismatchError);
+          });
+
+          it("should fail providing data if contexts on set and get do not match", () => {
+            const dataFixture = "DATA";
+            const contextOnSet = "document/1";
+            const contextOnGet = "document/2";
+            const controller = new DataFacadeController(editor);
+
+            controller.setData(dataFixture, { context: contextOnSet });
+
+            expect(() => controller.getData({ context: contextOnGet })).toThrow(ContextMismatchError);
+          });
+
+          (editorBinding === "bound" ? describe : describe.skip)("Bound Mode", () => {
+            it("should respect context also when getting data as result of editorial changes (same context scenario)", () => {
+              const dataFixture = "DATA";
+              const editedDataFixture = dataFixture.toLowerCase();
+              const contextOnSet = "document/1";
+              const contextOnGet = contextOnSet;
+              const controller = new DataFacadeController(editor);
+
+              controller.setData(dataFixture, { context: contextOnSet });
+
+              editor?.simulateEditorialUpdate(editedDataFixture);
+
+              expect(controller.getData({ context: contextOnGet })).toEqual(editedDataFixture);
+            });
+
+            it("should respect context also when getting data as result of editorial changes (expected failure due to different context)", () => {
+              const dataFixture = "DATA";
+              const editedDataFixture = dataFixture.toLowerCase();
+              const contextOnSet = "document/1";
+              const contextOnGet = "document/2";
+              const controller = new DataFacadeController(editor);
+
+              controller.setData(dataFixture, { context: contextOnSet });
+
+              editor?.simulateEditorialUpdate(editedDataFixture);
+
+              expect(() => controller.getData({ context: contextOnGet })).toThrow(ContextMismatchError);
+            });
+          });
+        });
+      });
+    });
+  });
+});

--- a/packages/ckeditor5-data-facade/jest.config.js
+++ b/packages/ckeditor5-data-facade/jest.config.js
@@ -1,0 +1,3 @@
+const jestConfig = require("@coremedia-internal/ckeditor5-jest-test-helpers/shared-jest.config.js");
+
+module.exports = { ...jestConfig };

--- a/packages/ckeditor5-data-facade/package.json
+++ b/packages/ckeditor5-data-facade/package.json
@@ -1,0 +1,52 @@
+{
+  "name": "@coremedia/ckeditor5-data-facade",
+  "version": "16.0.1-rc.0",
+  "description": "Facade to normalize data in uninterrupted flow data > data view > model > data view > data', so that data === data'.",
+  "keywords": [
+    "coremedia",
+    "ckeditor",
+    "ckeditor5",
+    "data"
+  ],
+  "engines": {
+    "node": "18",
+    "pnpm": "^8.6.9"
+  },
+  "license": "Apache-2.0",
+  "scripts": {
+    "build": "tsc --project ./tsconfig.release.json",
+    "clean": "pnpm clean:src && pnpm clean:dist",
+    "clean:src": "rimraf --glob \"src/**/*.@(js|js.map|d.ts|d.ts.map)\"",
+    "clean:dist": "rimraf ./dist",
+    "jest": "jest --passWithNoTests",
+    "jest:coverage": "jest --collect-coverage --passWithNoTests",
+    "npm-check-updates": "npm-check-updates --upgrade"
+  },
+  "main": "./src/index.ts",
+  "publishConfig": {
+    "main": "./src/index.js",
+    "types": "./src/index.d.ts"
+  },
+  "devDependencies": {
+    "@ckeditor/ckeditor5-autosave": "^39.0.2",
+    "@ckeditor/ckeditor5-core": "^39.0.2",
+    "@ckeditor/ckeditor5-engine": "^39.0.2",
+    "@ckeditor/ckeditor5-utils": "^39.0.2",
+    "@coremedia-internal/ckeditor5-jest-test-helpers": "^1.0.0",
+    "@types/jest": "^29.5.4",
+    "jest": "^29.7.0",
+    "jest-each": "^29.7.0",
+    "rimraf": "^5.0.1",
+    "typescript": "^4.9.5"
+  },
+  "peerDependencies": {
+    "@ckeditor/ckeditor5-autosave": "^39.0.2",
+    "@ckeditor/ckeditor5-core": "^39.0.2",
+    "@ckeditor/ckeditor5-engine": "^39.0.2",
+    "@ckeditor/ckeditor5-utils": "^39.0.2"
+  },
+  "dependencies": {
+    "@coremedia/ckeditor5-core-common": "16.0.1-rc.0",
+    "@coremedia/ckeditor5-logging": "16.0.1-rc.0"
+  }
+}

--- a/packages/ckeditor5-data-facade/package.json
+++ b/packages/ckeditor5-data-facade/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coremedia/ckeditor5-data-facade",
-  "version": "16.0.1-rc.0",
+  "version": "16.0.1-rc.1",
   "description": "Facade to normalize data in uninterrupted flow data > data view > model > data view > data', so that data === data'.",
   "keywords": [
     "coremedia",
@@ -47,7 +47,7 @@
     "@ckeditor/ckeditor5-utils": "^39.0.2"
   },
   "dependencies": {
-    "@coremedia/ckeditor5-core-common": "16.0.1-rc.0",
-    "@coremedia/ckeditor5-logging": "16.0.1-rc.0"
+    "@coremedia/ckeditor5-core-common": "16.0.1-rc.1",
+    "@coremedia/ckeditor5-logging": "16.0.1-rc.1"
   }
 }

--- a/packages/ckeditor5-data-facade/package.json
+++ b/packages/ckeditor5-data-facade/package.json
@@ -31,6 +31,7 @@
     "@ckeditor/ckeditor5-autosave": "^39.0.2",
     "@ckeditor/ckeditor5-core": "^39.0.2",
     "@ckeditor/ckeditor5-engine": "^39.0.2",
+    "@ckeditor/ckeditor5-ui": "^39.0.2",
     "@ckeditor/ckeditor5-utils": "^39.0.2",
     "@coremedia-internal/ckeditor5-jest-test-helpers": "^1.0.0",
     "@types/jest": "^29.5.4",

--- a/packages/ckeditor5-data-facade/src/CachedData.ts
+++ b/packages/ckeditor5-data-facade/src/CachedData.ts
@@ -1,0 +1,25 @@
+import { SetDataData, SetDataOptions } from "./DataControllerApi";
+import { DataContextOptions } from "./DataContextOptions";
+
+/**
+ * Represents cached data. In the context of the data facade feature, these
+ * are meant to be exposed in favor of the data hold within CKEditor 5, when
+ * we expect the data to be unchanged, yet.
+ */
+export interface CachedData {
+  /**
+   * The original set data.
+   */
+  data: SetDataData;
+  /**
+   * The original options used when setting the data.
+   */
+  options: SetDataOptions & DataContextOptions;
+  /**
+   * The internal version number of the CKEditor 5 model, that we know is
+   * representing the original set data. If on get, we see, that current
+   * version in the model and this version match, we will favor returning the
+   * cached data instead.
+   */
+  version?: number;
+}

--- a/packages/ckeditor5-data-facade/src/ContextMismatchError.ts
+++ b/packages/ckeditor5-data-facade/src/ContextMismatchError.ts
@@ -3,9 +3,29 @@
  * the current context anymore.
  */
 export class ContextMismatchError extends Error {
-  constructor(message?: string) {
+  /**
+   * The actual context as of previously set data.
+   */
+  readonly actual?: string;
+  /**
+   * The expected context data got requested for.
+   */
+  readonly expected?: string;
+
+  constructor(
+    message?: string,
+    contextInformation?: {
+      actual?: string;
+      expected?: string;
+    },
+  ) {
     super(message);
-    // https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-2.html
-    Object.setPrototypeOf(this, new.target.prototype);
+
+    this.actual = contextInformation?.actual;
+    this.expected = contextInformation?.expected;
+  }
+
+  override toString(): string {
+    return `ContextMismatchError: ${this.message} {actual=${this.actual}, expected=${this.expected}}`;
   }
 }

--- a/packages/ckeditor5-data-facade/src/ContextMismatchError.ts
+++ b/packages/ckeditor5-data-facade/src/ContextMismatchError.ts
@@ -1,0 +1,11 @@
+/**
+ * An error raised, when the context when getting the data does not match
+ * the current context anymore.
+ */
+export class ContextMismatchError extends Error {
+  constructor(message?: string) {
+    super(message);
+    // https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-2.html
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}

--- a/packages/ckeditor5-data-facade/src/DataApi.ts
+++ b/packages/ckeditor5-data-facade/src/DataApi.ts
@@ -1,0 +1,33 @@
+import { GetDataOptions, SetDataData, SetDataOptions } from "./DataControllerApi";
+import { DataContextOptions } from "./DataContextOptions";
+
+/**
+ * Data API to control in- and output to an instance of CKEditor 5.
+ */
+export interface DataApi {
+  /**
+   * Sets the data at an instance of CKEditor 5.
+   *
+   * @param data - data to set
+   * @param options - options for setting the data
+   */
+  setData(data: SetDataData, options?: SetDataOptions & DataContextOptions): void;
+
+  /**
+   * Gets the data from an instance of CKEditor 5.
+   *
+   * @param options - options for getting the data
+   * @returns the data or some signal for invalid data, if supported by implementation
+   */
+  getData(options?: GetDataOptions & DataContextOptions): string;
+}
+
+/**
+ * API for getting data.
+ */
+export type GetDataApi = Pick<DataApi, "getData">;
+
+/**
+ * API for setting data.
+ */
+export type SetDataApi = Pick<DataApi, "setData">;

--- a/packages/ckeditor5-data-facade/src/DataContextOptions.ts
+++ b/packages/ckeditor5-data-facade/src/DataContextOptions.ts
@@ -1,0 +1,10 @@
+/**
+ * Options to provide as context information.
+ */
+export interface DataContextOptions {
+  /**
+   * The current context for setting and getting data. Possibly, some ID
+   * the data is bound to.
+   */
+  context?: string;
+}

--- a/packages/ckeditor5-data-facade/src/DataControllerApi.ts
+++ b/packages/ckeditor5-data-facade/src/DataControllerApi.ts
@@ -1,0 +1,34 @@
+import type { DataController } from "@ckeditor/ckeditor5-engine";
+
+/**
+ * Instance type of the DataController.
+ */
+export type DataControllerInstance = InstanceType<typeof DataController>;
+/**
+ * Method for setting data.
+ */
+export type SetDataType = DataControllerInstance["set"];
+/**
+ * Method for getting data.
+ */
+export type GetDataType = DataControllerInstance["get"];
+/**
+ * Parameters for setting data.
+ */
+export type SetDataParameters = Parameters<SetDataType>;
+/**
+ * Parameters for getting data.
+ */
+export type GetDataParameters = Parameters<GetDataType>;
+/**
+ * Type for `data` when setting data.
+ */
+export type SetDataData = SetDataParameters[0];
+/**
+ * Type for `options` when setting data.
+ */
+export type SetDataOptions = SetDataParameters[1];
+/**
+ * Type for `options` when getting data.
+ */
+export type GetDataOptions = GetDataParameters[0];

--- a/packages/ckeditor5-data-facade/src/DataFacade.ts
+++ b/packages/ckeditor5-data-facade/src/DataFacade.ts
@@ -1,12 +1,12 @@
-import { Editor, EditorReadyEvent, Plugin } from "@ckeditor/ckeditor5-core";
+import { type Editor, type EditorReadyEvent, Plugin } from "@ckeditor/ckeditor5-core";
 import { reportInitEnd, reportInitStart } from "@coremedia/ckeditor5-core-common";
-import { GetDataOptions, SetDataData, SetDataOptions } from "./DataControllerApi";
-import { DataContextOptions } from "./DataContextOptions";
+import type { GetDataOptions, SetDataData, SetDataOptions } from "./DataControllerApi";
+import type { DataContextOptions } from "./DataContextOptions";
 import { DataFacadeController } from "./DataFacadeController";
-import { DataApi } from "./DataApi";
+import type { DataApi } from "./DataApi";
 import { Autosave } from "@ckeditor/ckeditor5-autosave";
-import { AutosaveAdapter } from "@ckeditor/ckeditor5-autosave/src/autosave";
-import { DataFacadeConfig } from "./DataFacadeConfig";
+import type { AutosaveAdapter } from "@ckeditor/ckeditor5-autosave/src/autosave";
+import type { DataFacadeConfig } from "./DataFacadeConfig";
 
 /**
  * This facade is meant to control data in- and output. It ensures that any

--- a/packages/ckeditor5-data-facade/src/DataFacade.ts
+++ b/packages/ckeditor5-data-facade/src/DataFacade.ts
@@ -1,0 +1,118 @@
+import { Editor, EditorReadyEvent, Plugin } from "@ckeditor/ckeditor5-core";
+import { reportInitEnd, reportInitStart } from "@coremedia/ckeditor5-core-common";
+import { GetDataOptions, SetDataData, SetDataOptions } from "./DataControllerApi";
+import { DataContextOptions } from "./DataContextOptions";
+import { DataFacadeController } from "./DataFacadeController";
+import { DataApi } from "./DataApi";
+import { Autosave } from "@ckeditor/ckeditor5-autosave";
+import { AutosaveAdapter } from "@ckeditor/ckeditor5-autosave/src/autosave";
+import { DataFacadeConfig } from "./DataFacadeConfig";
+
+/**
+ * This facade is meant to control data in- and output. It ensures that any
+ * data set is returned unchanged, unless editorial actions have been performed
+ * meanwhile. Thus, it grants that in a control flow set-data directly followed
+ * by get-data the retrieved data are strictly equal to the ones set before.
+ *
+ * **Motivation**: For any control flow set-data and get-data it is perfectly
+ * valid that the retrieved data may have subtle differences to the previously
+ * set data.
+ *
+ * Given HTML as data format, the following representations are equivalent
+ * regarding the corresponding representation within a browser (unless
+ * CSS rules make a difference here):
+ *
+ * ```html
+ * <em><strong id="7fac" class="pretty">Lorem</strong></em>
+ * ```
+ *
+ * ```html
+ * <strong class="pretty" id="7fac"><em>Lorem</em></strong>
+ * ```
+ *
+ * Depending on the storage backend, the CKEditor instance is bound to it is
+ * possibly important not to signal a change when the change is irrelevant. It
+ * may cause overhead such as additional network communication, subsequent
+ * publication steps or even may trigger translation processes.
+ */
+export class DataFacade extends Plugin implements DataApi, AutosaveAdapter {
+  public static readonly pluginName = "DataFacade";
+  readonly #dataController: DataFacadeController;
+  readonly #config: DataFacadeConfig;
+
+  /**
+   * @inheritDoc
+   */
+  public static get requires() {
+    return [Autosave] as const;
+  }
+
+  constructor(editor: Editor) {
+    super(editor);
+
+    this.#config = editor.config.get("dataFacade") ?? {};
+
+    this.#dataController = new DataFacadeController(editor);
+  }
+
+  /**
+   * Initializes plugin and starts waiting for the editor to become ready.
+   */
+  init(): void {
+    const initInformation = reportInitStart(this);
+    const { editor } = this;
+
+    // Register as save adapter for `Autosave`.
+    editor.plugins.get(Autosave).adapter = this;
+
+    // Propagates _editor ready_. This ensures that our set data win over
+    // the initialization behavior, which respects `EditorConfig.initialData`.
+    editor.once<EditorReadyEvent>(
+      "ready",
+      () => {
+        this.#dataController.init();
+      },
+      // Propagate the state late.
+      { priority: "lowest" },
+    );
+    reportInitEnd(initInformation);
+  }
+
+  /**
+   * Access to controller interface.
+   */
+  get data(): DataFacadeController {
+    return this.#dataController;
+  }
+
+  /**
+   * Forwards `save` from `Autosave` to the configured `save` method using
+   * the `GetDataApi`.
+   */
+  async save(): Promise<void> {
+    await this.#config?.save?.(this);
+  }
+
+  /**
+   * Sets the data to set at editor.
+   * If the editor is not ready yet, data will be forwarded as soon as the
+   * editor is ready.
+   *
+   * @param data - data to set
+   * @param options - options for setting data
+   */
+  setData(data: SetDataData, options: SetDataOptions & DataContextOptions = {}): void {
+    this.#dataController.setData(data, options);
+  }
+
+  /**
+   * Gets the data, possibly from cache either if the editor is not ready yet,
+   * or if the data are considered equal to the data set before.
+   *
+   * @param options - options for retrieving data; note, that despite the
+   * `rootName` any other options are ignored if data are retrieved from cache.
+   */
+  getData(options: GetDataOptions & DataContextOptions = {}): string {
+    return this.#dataController.getData(options);
+  }
+}

--- a/packages/ckeditor5-data-facade/src/DataFacadeConfig.ts
+++ b/packages/ckeditor5-data-facade/src/DataFacadeConfig.ts
@@ -1,0 +1,47 @@
+import { GetDataApi } from "./DataApi";
+
+/**
+ * Save method type.
+ */
+export type Save = (dataApi: GetDataApi) => Promise<never>;
+
+/**
+ * The configuration of the `DataFacade`.
+ *
+ * ```typescript
+ * ClassicEditor
+ *   .create(editorElement, {
+ *      autosave: {
+ *        save( editor: Editor ): Promise<unknown> {
+ *          // Typically skipped. Use `dataFacade` instead.
+ *        },
+ *        // Waiting time configured here, will then forward to `dataFacade`.
+ *        waitingTime: 2000,
+ *      }
+ *   });
+ *   .then( ... )
+ *   .catch( ... );
+ * ```
+ */
+export interface DataFacadeConfig {
+  /**
+   * The callback to be executed when the data needs to be saved.
+   *
+   * This function must return a promise that should be resolved when the data
+   * is successfully saved.
+   *
+   * ```typescript
+   * ClassicEditor
+   *   .create(editorElement, {
+   *     dataFacade: {
+   *       save(dataApi: GetDataApi) {
+   *         return saveData(dataApi.getData());
+   *       },
+   *     },
+   *   });
+   *   .then( ... )
+   *   .catch( ... );
+   * ```
+   */
+  save?: Save;
+}

--- a/packages/ckeditor5-data-facade/src/DataFacadeConfig.ts
+++ b/packages/ckeditor5-data-facade/src/DataFacadeConfig.ts
@@ -3,7 +3,7 @@ import { GetDataApi } from "./DataApi";
 /**
  * Save method type.
  */
-export type Save = (dataApi: GetDataApi) => Promise<never>;
+export type Save = (dataApi: GetDataApi) => Promise<void>;
 
 /**
  * The configuration of the `DataFacade`.

--- a/packages/ckeditor5-data-facade/src/DataFacadeController.ts
+++ b/packages/ckeditor5-data-facade/src/DataFacadeController.ts
@@ -277,7 +277,10 @@ export class DataFacadeController implements DataApi {
     const { context: actualContext } = options;
 
     if (expectedContext !== actualContext) {
-      throw new ContextMismatchError(`Data Context Mismatch: actual: ${actualContext}, expected: ${expectedContext}`);
+      throw new ContextMismatchError(`Data Context Mismatch: actual: ${actualContext}, expected: ${expectedContext}`, {
+        actual: actualContext,
+        expected: expectedContext,
+      });
     }
 
     if (!editor || cachedVersion === editor.model.document.version) {

--- a/packages/ckeditor5-data-facade/src/DataFacadeController.ts
+++ b/packages/ckeditor5-data-facade/src/DataFacadeController.ts
@@ -1,0 +1,303 @@
+import { LoggerProvider } from "@coremedia/ckeditor5-logging";
+import type { GetDataOptions, SetDataData, SetDataOptions } from "./DataControllerApi";
+import { DataContextOptions } from "./DataContextOptions";
+import type { Editor } from "@ckeditor/ckeditor5-core";
+import { DataApi } from "./DataApi";
+import { CachedData } from "./CachedData";
+import { ContextMismatchError } from "./ContextMismatchError";
+import { CKEditorError } from "@ckeditor/ckeditor5-utils";
+import { DataFacade } from "./DataFacade";
+
+/**
+ * Controller for getting and setting data. It prefers providing data on get
+ * from the previously set data if no editorial actions have been applied so
+ * far.
+ *
+ * The controller may be used in three modes: standalone, delegating, and
+ * embedded.
+ *
+ * **Standalone Mode**
+ *
+ * The _standalone_ mode may be used if you create the CKEditor instance late
+ * and require to set and retrieve data already before. A standalone controller
+ * may at any time be turned into a delegating controller.
+ *
+ * **Embedded Mode**
+ *
+ * The _embedded_ mode is controlled by `DataFacade` plugin. The plugin will
+ * maintain this embedded instance of the controller and use it when binding
+ * to the `Autosave` plugin.
+ *
+ * **Delegating Mode**
+ *
+ * A controller in _standalone_ mode may (once) be turned into delegating
+ * mode. The setup requires the `DataFacade` plugin to be installed. The
+ * standalone controller will then bind to the controller held by the
+ * `DataFacade`, propagate any possibly already set data and will only
+ * use delegate calls afterward.
+ *
+ * **Recommended Mixed Setup**
+ *
+ * The recommended setup, if you require the controller in the standalone mode,
+ * is to switch to delegating mode, as soon as the editor is available. The
+ * control flow may be roughly sketched as follows:
+ *
+ * ```typescript
+ * import { DataFacade, DataFacadeController } from "@coremedia/ckeditor5-data-facade";
+ *
+ * const standaloneController = new DataFacadeController();
+ *
+ * // You may set (and get) data already now.
+ * standaloneController.setData("<p>Hello Standalone!</p>");
+ *
+ * ClassicEditor
+ *   .create( document.querySelector( '#editor' ), {
+ *     plugins: [
+ *       // Transitive Dependency on Autosave.
+ *       DataFacade,
+ *     ],
+ *     autosave: {
+ *       // no save needed
+ *        waitingTime: 5000, // in ms
+ *     },
+ *     dataFacade: {
+ *       save(controller) {
+ *         // saveData providing a promise to store data
+ *         // in an external data storage.
+ *         return saveData( controller.getData() );
+ *       }
+ *     }
+ *   })
+ *   .then( (editor) => {
+ *     // Will turn the controller into delegating mode.
+ *     standaloneController.init(editor);
+ *   })
+ *   .catch( (error) => {
+ *     console.error( error );
+ *   } );
+ *
+ * // Now the standalone controller delegates to the
+ * // embedded controller.
+ * standaloneController.setData("<p>Hello Delegating!</p>");
+ * ```
+ */
+export class DataFacadeController implements DataApi {
+  #logger = LoggerProvider.getLogger("DataFacadeController");
+  #editor?: Editor;
+  #cachedData?: CachedData;
+  /**
+   * Possible delegate to controller directly bound to CKEditor 5 via
+   * `DataFacade` plugin. Only expect to be set for a `DataFacadeController`
+   * used in the standalone mode.
+   */
+  #delegate?: DataFacadeController;
+
+  /**
+   * Creates a data controller instance. Outside a plugin context, it is not
+   * required to provide an `editor`. From within a plugin context, providing
+   * the `editor` is expected.
+   *
+   * @param editor - optional editor to bind to
+   */
+  constructor(editor?: Editor) {
+    this.#editor = editor;
+  }
+
+  /**
+   * Initialize controller, to possibly forward data already set. Outside
+   * a plugin context, requires the `editor` to be given. When used from within
+   * a plugin, it is unnecessary to provide an editor. But if an editor is
+   * provided, it must be the same as the original one when creating this
+   * data controller instance.
+   *
+   * @param editor - optional editor to bind to
+   */
+  init(editor?: Editor): void {
+    if (this.editor) {
+      if (editor && this.editor !== editor) {
+        throw new Error("Already initialized editor. Cannot rebind to different editor instance.");
+      }
+    } else {
+      this.#editor = editor;
+    }
+
+    this.#initDelegation();
+    this.#propagateData();
+  }
+
+  /**
+   * When used in the standalone before, we will later synchronize with a
+   * possibly existing `DataFacade` bound to the instance of CKEditor 5.
+   *
+   * Note that the `DataFacadeController` may also be used only in
+   * a standalone mode, where you will not benefit from the `Autosave`
+   * integration.
+   */
+  #initDelegation(): void {
+    const logger = this.#logger;
+    const editor = this.#editor;
+
+    if (!editor) {
+      return;
+    }
+
+    const { plugins } = editor;
+
+    if (plugins.has(DataFacade)) {
+      logger.debug("Running in standalone mode only. No DataFacade available for given at instance.");
+      return;
+    }
+
+    const dataFacade = plugins.get(DataFacade);
+
+    const { data: boundDataFacadeController } = dataFacade;
+
+    if (boundDataFacadeController === this) {
+      // No need to set up the delegation. This instance is already directly
+      // bound to the `DataFacade`.
+      return;
+    }
+
+    if (this.#delegate) {
+      if (this.#delegate !== boundDataFacadeController) {
+        throw new Error("Cannot switch delegation.");
+      }
+      logger.debug("Skipping re-initialization of delegation.");
+      return;
+    }
+
+    this.#delegate = boundDataFacadeController;
+
+    /*
+     * The Expected State: Standalone Before
+     *
+     * We may now safely assume that this DataFacadeController got used in the
+     * standalone mode. We expect that we may hold up-to-date data to possibly
+     * forward to the existing DataFacadeController bound to CKEditor via
+     * DataFacade plugin.
+     */
+
+    this.#initiallyPropagateDataToDelegate(boundDataFacadeController);
+  }
+
+  #initiallyPropagateDataToDelegate(delegate: DataFacadeController): void {
+    const cachedData = this.#cachedData;
+
+    if (!cachedData) {
+      // Nothing to propagate.
+      return;
+    }
+
+    const { data, options } = cachedData;
+
+    delegate.setData(data, options);
+
+    this.#cachedData = undefined;
+  }
+
+  /**
+   * Access editor, this instance is bound to.
+   */
+  get editor(): Editor | undefined {
+    return this.#delegate?.editor ?? this.#editor;
+  }
+
+  /**
+   * Conditionally propagates the data to the editor. Will skip propagation,
+   * if either the editor is not available yet, there are no cached data
+   * (thus, no previously set data), or if this controller is running in
+   * delegate mode.
+   */
+  #propagateData(): void {
+    const { editor } = this;
+    const cachedData = this.#cachedData;
+
+    if (!editor || !cachedData || this.#delegate) {
+      /*
+       * Do not propagate:
+       *
+       * – if there is no editor, yet
+       * – if we do not have any data set yet
+       * – if we are in delegating mode
+       */
+      return;
+    }
+
+    editor.data.set(cachedData.data, cachedData.options);
+
+    cachedData.version = editor.model.document.version;
+  }
+
+  /**
+   * Sets the data to set at editor.
+   * If the editor is not ready yet, data will be forwarded as soon as the
+   * editor is ready.
+   *
+   * @param data - data to set
+   * @param options - options for setting data
+   */
+  setData(data: SetDataData, options: SetDataOptions & DataContextOptions = {}): void {
+    if (this.#delegate) {
+      this.#delegate.setData(data, options);
+      return;
+    }
+
+    this.#cachedData = {
+      data,
+      options,
+    };
+
+    this.#propagateData();
+  }
+
+  /**
+   * Gets the data, possibly from cache either if the editor is not ready yet,
+   * or if the data are considered equal to the data set before.
+   *
+   * @param options - options for retrieving data; note, that despite the
+   * `rootName` any other options are ignored if data are retrieved from cache.
+   */
+  getData(options: GetDataOptions & DataContextOptions = {}): string {
+    if (this.#delegate) {
+      return this.#delegate.getData(options);
+    }
+
+    const { editor } = this;
+    const cachedData = this.#cachedData;
+
+    if (!cachedData) {
+      return editor?.data.get(options) ?? "";
+    }
+
+    const {
+      data,
+      options: { context: expectedContext },
+      version: cachedVersion,
+    } = cachedData;
+    const { context: actualContext } = options;
+
+    if (expectedContext !== actualContext) {
+      throw new ContextMismatchError(`Data Context Mismatch: actual: ${actualContext}, expected: ${expectedContext}`);
+    }
+
+    if (!editor || cachedVersion === editor.model.document.version) {
+      return this.#pickData(data, options);
+    }
+
+    return editor.data.get(options);
+  }
+
+  #pickData(data: SetDataData, options: Pick<NonNullable<GetDataOptions>, "rootName">): string {
+    const { rootName = "main" } = options;
+    if (typeof data === "string") {
+      return data;
+    }
+    if (rootName in data) {
+      return data[rootName];
+    }
+
+    // We simulate the failure from DataController, as if the requested root
+    // does not exist.
+    throw new CKEditorError("datacontroller-get-non-existent-root", this.editor?.data);
+  }
+}

--- a/packages/ckeditor5-data-facade/src/DataFacadeController.ts
+++ b/packages/ckeditor5-data-facade/src/DataFacadeController.ts
@@ -6,7 +6,6 @@ import { DataApi } from "./DataApi";
 import { CachedData } from "./CachedData";
 import { ContextMismatchError } from "./ContextMismatchError";
 import { CKEditorError } from "@ckeditor/ckeditor5-utils";
-import { DataFacade } from "./DataFacade";
 
 /**
  * Controller for getting and setting data. It prefers providing data on get
@@ -82,9 +81,6 @@ import { DataFacade } from "./DataFacade";
  * ```
  */
 export class DataFacadeController implements DataApi {
-  static #instanceCount = 0;
-  readonly instanceId: number;
-
   #logger = LoggerProvider.getLogger("DataFacadeController");
   #editor?: Editor;
   #cachedData?: CachedData;
@@ -104,7 +100,6 @@ export class DataFacadeController implements DataApi {
    */
   constructor(editor?: Editor) {
     this.#editor = editor;
-    this.instanceId = DataFacadeController.#instanceCount++;
   }
 
   /**
@@ -156,12 +151,12 @@ export class DataFacadeController implements DataApi {
 
     const { plugins } = editor;
 
-    if (!plugins.has(DataFacade)) {
+    if (!plugins.has("DataFacade")) {
       logger.debug("Running in standalone mode only. No DataFacade available for given at instance.");
       return;
     }
 
-    const dataFacade = plugins.get(DataFacade);
+    const dataFacade = plugins.get("DataFacade");
 
     const { data: boundDataFacadeController } = dataFacade;
 

--- a/packages/ckeditor5-data-facade/src/augmentation.ts
+++ b/packages/ckeditor5-data-facade/src/augmentation.ts
@@ -1,0 +1,14 @@
+import type { DataFacade, DataFacadeConfig } from "./index";
+
+declare module "@ckeditor/ckeditor5-core" {
+  interface PluginsMap {
+    [DataFacade.pluginName]: DataFacade;
+  }
+
+  interface EditorConfig {
+    /**
+     * The configuration of the `DataFacade`.
+     */
+    dataFacade?: DataFacadeConfig;
+  }
+}

--- a/packages/ckeditor5-data-facade/src/index-doc.ts
+++ b/packages/ckeditor5-data-facade/src/index-doc.ts
@@ -1,0 +1,28 @@
+/**
+ * Provides an additional control layer for setting and getting data.
+ *
+ * @module ckeditor5-data-facade
+ */
+
+export type { ContextMismatchError } from "./ContextMismatchError";
+
+export type { DataApi, GetDataApi, SetDataApi } from "./DataApi";
+
+export type { DataContextOptions } from "./DataContextOptions";
+
+export type {
+  GetDataType,
+  GetDataOptions,
+  GetDataParameters,
+  SetDataData,
+  SetDataOptions,
+  SetDataParameters,
+  SetDataType,
+  DataControllerInstance,
+} from "./DataControllerApi";
+
+export { DataFacade } from "./DataFacade";
+
+export type { DataFacadeConfig, Save } from "./DataFacadeConfig";
+
+export { DataFacadeController } from "./DataFacadeController";

--- a/packages/ckeditor5-data-facade/src/index.ts
+++ b/packages/ckeditor5-data-facade/src/index.ts
@@ -1,0 +1,28 @@
+/**
+ * @module ckeditor5-data-facade
+ */
+
+export type { ContextMismatchError } from "./ContextMismatchError";
+
+export type { DataApi, GetDataApi, SetDataApi } from "./DataApi";
+
+export type { DataContextOptions } from "./DataContextOptions";
+
+export type {
+  GetDataType,
+  GetDataOptions,
+  GetDataParameters,
+  SetDataData,
+  SetDataOptions,
+  SetDataParameters,
+  SetDataType,
+  DataControllerInstance,
+} from "./DataControllerApi";
+
+export { DataFacade } from "./DataFacade";
+
+export type { DataFacadeConfig, Save } from "./DataFacadeConfig";
+
+export { DataFacadeController } from "./DataFacadeController";
+
+import "./augmentation";

--- a/packages/ckeditor5-data-facade/src/index.ts
+++ b/packages/ckeditor5-data-facade/src/index.ts
@@ -2,7 +2,7 @@
  * @module ckeditor5-data-facade
  */
 
-export type { ContextMismatchError } from "./ContextMismatchError";
+export { ContextMismatchError } from "./ContextMismatchError";
 
 export type { DataApi, GetDataApi, SetDataApi } from "./DataApi";
 

--- a/packages/ckeditor5-data-facade/src/tsdoc.json
+++ b/packages/ckeditor5-data-facade/src/tsdoc.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+  "extends": ["../../../tsdoc-typedoc.json"]
+}

--- a/packages/ckeditor5-data-facade/tsconfig.json
+++ b/packages/ckeditor5-data-facade/tsconfig.json
@@ -3,7 +3,6 @@
   "include": [
     "./__mocks__",
     "./__tests__",
-    "./src",
-    "../../typings"
+    "./src"
   ]
 }

--- a/packages/ckeditor5-data-facade/tsconfig.json
+++ b/packages/ckeditor5-data-facade/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": [
+    "./__mocks__",
+    "./__tests__",
+    "./src",
+    "../../typings"
+  ]
+}

--- a/packages/ckeditor5-data-facade/tsconfig.release.json
+++ b/packages/ckeditor5-data-facade/tsconfig.release.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": [
+    "./__mocks__",
+    "./__tests__"
+  ]
+}

--- a/packages/ckeditor5-data-facade/typedoc.json
+++ b/packages/ckeditor5-data-facade/typedoc.json
@@ -1,0 +1,5 @@
+{
+  "extends": ["../../typedoc.base.json"],
+  "entryPoints": ["./src/index-doc.ts"],
+  "name": "ckeditor5-coremedia-link"
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1026,6 +1026,49 @@ importers:
         specifier: ^4.9.5
         version: 4.9.5
 
+  packages/ckeditor5-data-facade:
+    dependencies:
+      '@coremedia/ckeditor5-core-common':
+        specifier: 16.0.1-rc.1
+        version: link:../ckeditor5-core-common
+      '@coremedia/ckeditor5-logging':
+        specifier: 16.0.1-rc.1
+        version: link:../ckeditor5-logging
+    devDependencies:
+      '@ckeditor/ckeditor5-autosave':
+        specifier: ^39.0.2
+        version: 39.0.2
+      '@ckeditor/ckeditor5-core':
+        specifier: ^39.0.2
+        version: 39.0.2
+      '@ckeditor/ckeditor5-engine':
+        specifier: ^39.0.2
+        version: 39.0.2
+      '@ckeditor/ckeditor5-ui':
+        specifier: ^39.0.2
+        version: 39.0.2
+      '@ckeditor/ckeditor5-utils':
+        specifier: ^39.0.2
+        version: 39.0.2
+      '@coremedia-internal/ckeditor5-jest-test-helpers':
+        specifier: ^1.0.0
+        version: link:../ckeditor5-jest-test-helpers
+      '@types/jest':
+        specifier: ^29.5.4
+        version: 29.5.5
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@18.17.18)
+      jest-each:
+        specifier: ^29.7.0
+        version: 29.7.0
+      rimraf:
+        specifier: ^5.0.1
+        version: 5.0.1
+      typescript:
+        specifier: ^4.9.5
+        version: 4.9.5
+
   packages/ckeditor5-dataprocessor-support:
     dependencies:
       '@coremedia/ckeditor5-common':
@@ -2536,7 +2579,6 @@ packages:
     dependencies:
       ckeditor5: 39.0.2
       lodash-es: 4.17.21
-    dev: false
 
   /@ckeditor/ckeditor5-basic-styles@39.0.2:
     resolution: {integrity: sha512-sp5sfE4d8Tng/zIssBK+SgaEkPfGcbmoGkjbHhPlWYAoQB9ONwvWkRZy9s3C+H0gfsEj3EqqxUKY70Us0yT8rA==}
@@ -6075,10 +6117,10 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/expect-utils': 29.5.0
-      jest-get-type: 29.4.3
+      jest-get-type: 29.6.3
       jest-matcher-utils: 29.5.0
       jest-message-util: 29.5.0
-      jest-util: 29.5.0
+      jest-util: 29.7.0
     dev: true
 
   /expect@29.7.0:
@@ -7315,11 +7357,6 @@ packages:
       jest-mock: 29.7.0
       jest-util: 29.7.0
 
-  /jest-get-type@29.4.3:
-    resolution: {integrity: sha512-J5Xez4nRRMjk8emnTpWrlkyb9pfRQQanDrvWHhsR1+VUfbwxi30eVcZFlcdGInRibU4G5LwHXpI7IRHU0CY+gg==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    dev: true
-
   /jest-get-type@29.6.3:
     resolution: {integrity: sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -7582,6 +7619,7 @@ packages:
       ci-info: 3.8.0
       graceful-fs: 4.2.11
       picomatch: 2.3.1
+    dev: false
 
   /jest-util@29.7.0:
     resolution: {integrity: sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==}


### PR DESCRIPTION
This PR introduces a workaround, that we previously only provided within the context of CoreMedia Studio: Prevent saving (different) data on "no semantic change".

It is meant to work around a corresponding missing feature within CKEditor 5 itself. See ckeditor/ckeditor5#11900 for details.

## No Semantic Change

The PR comes with example-data to apply, that demonstrate the "no semantic change" issue. It boils down to these examples:

```html
<em><strong>ItalicBold</strong></em>
<strong><em>BoldItalic</em></strong>

<a href="https://example.org/" target="_blank">href, target</a>
<a target="_blank" href="https://example.org/">target, href</a>
```

In a sequence `data → data view → model → data view → data` CKEditor 5 is free to choose any of the representations and will (most likely) normalize them to one suitable representation like:

```html
<em><strong>ItalicBold</strong></em>
<em><strong>BoldItalic</strong></em>

<a href="https://example.org/" target="_blank">href, target</a>
<a href="https://example.org/" target="_blank">target, href</a>
```

## Why bad?

The default behavior of CKEditor 5 may be considered a good practice, as it will, for example, remove unknown attributes and elements, too (unless GHS preserves them). You will find detailed reasons why not to use this new feature within the provided `README.md`.

But in the context of external storage, where changes also trigger subsequent processes, such "normalization" may trigger expensive actions. In the context of CoreMedia CMS, this ranges from triggering an auto-checkout of documents just by opening them (and blocking others from editing) up to subsequent translation and publication processes.

Thus, if you value the benefit of preventing these "unintended" changes from being propagated, then this new data facade is for you.

## ⚠ Prior to Merge, Drop Proof-of-Concept commit

This PR contains, as last commit, a "proof-of-concept" to ease testing the feature. These changes are meant to be applied later, when conflicting changes have been applied (see BBCode data-processor).

## 👀 See Also

* ckeditor/ckeditor5#11900
* Replaces: #160
