### PR TITLE
Validate peer dependencies

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -54,6 +54,8 @@ jobs:
           git config --global user.email 'coremedia-ci@coremedia.com'
       - name: Install
         run: pnpm install
+      - name: "Validate peerDependencies"
+        run: pnpm script:validate-peers
       - name: Set prerelease version (if triggered manually)
         if: github.event_name == 'workflow_dispatch'
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,6 +73,8 @@ jobs:
           git pull
       - name: Install
         run: pnpm install
+      - name: "Validate peerDependencies"
+        run: pnpm script:validate-peers
       # BY MANUAL TRIGGER ONLY!
       # Set the release version to actual MAJOR.MINOR.PATCH version.
       # If a prerelease is triggered manually, we keep the prerelease version for this workflow.

--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
     "preinstall": "node ./scripts/check-pnpm.mjs",
     "start": "pnpm --recursive --filter \"@coremedia/ckeditor5-app\" start",
     "update-latest": "pnpm update --interactive --latest --recursive",
-    "script:version": "node ./scripts/version.mjs"
+    "script:version": "node ./scripts/version.mjs",
+    "script:validate-peers": "node ./scripts/validate-peers.mjs"
   },
   "dependencies": {
     "@coremedia/set-version": "1.1.1"
@@ -75,6 +76,7 @@
     "rimraf": "^5.0.1",
     "semver": "^7.5.4",
     "typedoc": "^0.25.1",
-    "typescript": "^4.9.5"
+    "typescript": "^4.9.5",
+    "validate-peer-dependencies": "^2.2.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,6 +63,9 @@ importers:
       typescript:
         specifier: ^4.9.5
         version: 4.9.5
+      validate-peer-dependencies:
+        specifier: ^2.2.0
+        version: 2.2.0
 
   app:
     dependencies:
@@ -8501,6 +8504,18 @@ packages:
   /path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
 
+  /path-root-regex@0.1.2:
+    resolution: {integrity: sha512-4GlJ6rZDhQZFE0DPVKh0e9jmZ5egZfxTkp7bcRDuPlJXbAwhxcl2dINPUAsjLdejqaLsCeg8axcLjIbvBjN4pQ==}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
+  /path-root@0.1.1:
+    resolution: {integrity: sha512-QLcPegTHF11axjfojBIoDygmS2E3Lf+8+jI6wOVmNVenrKSo3mFdSGiIgdSHenczw3wPtlVMQaFVwGmM7BJdtg==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      path-root-regex: 0.1.2
+    dev: true
+
   /path-scurry@1.10.1:
     resolution: {integrity: sha512-MkhCqzzBEpPvxxQ71Md0b1Kk51W01lrYvlMzSUaIzNsODdd7mqhiimSZlr+VegAz5Z6Vzt9Xg2ttE//XBhH3EQ==}
     engines: {node: '>=16 || 14 >=14.17'}
@@ -9299,6 +9314,13 @@ packages:
   /resolve-from@5.0.0:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
     engines: {node: '>=8'}
+
+  /resolve-package-path@4.0.3:
+    resolution: {integrity: sha512-SRpNAPW4kewOaNUt8VPqhJ0UMxawMwzJD8V7m1cJfdSTK9ieZwS6K7Dabsm4bmLFM96Z5Y/UznrpG5kt1im8yA==}
+    engines: {node: '>= 12'}
+    dependencies:
+      path-root: 0.1.1
+    dev: true
 
   /resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
@@ -10303,6 +10325,14 @@ packages:
       '@jridgewell/trace-mapping': 0.3.19
       '@types/istanbul-lib-coverage': 2.0.4
       convert-source-map: 1.9.0
+
+  /validate-peer-dependencies@2.2.0:
+    resolution: {integrity: sha512-8X1OWlERjiUY6P6tdeU9E0EwO8RA3bahoOVG7ulOZT5MqgNDUO/BQoVjYiHPcNe+v8glsboZRIw9iToMAA2zAA==}
+    engines: {node: '>= 12'}
+    dependencies:
+      resolve-package-path: 4.0.3
+      semver: 7.5.4
+    dev: true
 
   /vanilla-colorful@0.7.2:
     resolution: {integrity: sha512-z2YZusTFC6KnLERx1cgoIRX2CjPRP0W75N+3CC6gbvdX5Ch47rZkEMGO2Xnf+IEmi3RiFLxS18gayMA27iU7Kg==}

--- a/scripts/validate-peers.mjs
+++ b/scripts/validate-peers.mjs
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+
+import validatePeerDependencies from "validate-peer-dependencies";
+import fs from "node:fs/promises";
+import path from "node:path";
+
+/**
+ * Get all direct descendents of a given directory as full path.
+ * @param source - directory to scan
+ * @returns {Promise<string[]>} - full paths of directories that are a direct
+ * descendent of the given directory
+ */
+const getDirectories = async (source) =>
+  (await fs.readdir(source, { withFileTypes: true, encoding: "utf8" }))
+    .filter((dirent) => dirent.isDirectory())
+    .map((dirent) => path.join(dirent.path, dirent.name));
+
+/**
+ * Reports an observed failure to console.
+ *
+ * @param result - Result object of validatePeerDependencies
+ * @see <https://github.com/rwjblue/validate-peer-dependencies>
+ */
+const reportFailure = (result) => {
+  const { packagePath, incompatibleRanges, missingPeerDependencies } = result;
+  console.error(`${packagePath}:`);
+  if (missingPeerDependencies?.length ?? 0 > 0) {
+    const descriptors = missingPeerDependencies.map(({
+                                                       name,
+                                                       specifiedPeerDependencyRange
+                                                     }) => `${name}:${specifiedPeerDependencyRange}`);
+    console.error(`  Missing peerDependencies (${missingPeerDependencies.length}):`);
+    descriptors.forEach((descriptor) => console.error(`    * ${descriptor}`));
+  }
+  if (incompatibleRanges?.length ?? 0 > 0) {
+    const descriptors = incompatibleRanges.map(({
+                                                  name,
+                                                  specifiedPeerDependencyRange,
+                                                  version
+                                                }) => `${name}:${specifiedPeerDependencyRange} (is: ${version})`);
+    console.error(`  Incompatible peerDependencies (${incompatibleRanges.length}):`);
+    descriptors.forEach((descriptor) => console.error(`    * ${descriptor}`));
+  }
+};
+
+/**
+ * Validates if the `package.json` in given (or: nearest) directory has
+ * issues regarding its `peerDependencies`.
+ *
+ * @param dirName - directory name to start scanning
+ * @returns {boolean} - `false` if there are no issues, `true` if there are
+ * issues, that got reported to console
+ */
+const hasPeerDependencyIssues = (dirName) => {
+  let hasFailure = false;
+  const handleFailure = (result) => {
+    hasFailure = true;
+    reportFailure(result);
+  };
+  validatePeerDependencies(dirName, { handleFailure });
+  return hasFailure;
+};
+
+// Iterates through all `package.json` in `packages/` to scan for issues
+// regarding peerDependencies.
+void getDirectories("packages")
+  .then((dirs) => {
+
+    const packageJsonWithIssues = dirs
+      .map((path) => hasPeerDependencyIssues(path))
+      .filter(Boolean);
+
+    if (packageJsonWithIssues.length !== 0) {
+      console.error(`Detected violated peerDependencies: ${packageJsonWithIssues.length})`);
+      process.exit(1);
+    } else {
+      console.info("No peerDependencies violations detected.");
+    }
+  });


### PR DESCRIPTION
Adds the opt-in to validate `peerDependencies` if they match the actual dependencies.

This check works best for fixed versions, which we may want to introduce anyway, as it aligns with the CKEditor 5 packages and as it is a CKEditor 5 requirement that a deliverable only refers to one CKEditor 5 version for all used packages.

### 🔎 Review Hint

* Change one of the `peerDependencies` for a CKEditor 5 package to `39.0.0` (we are at `39.0.2`, currently).
* Run `pnpm script:validate-peers`

Regarding the "script" prefix: This helps to prevent possibly collisions with internal `pnpm` actions. While not relevant for `validate-peers`, we had issues with `version`, why we had to introduce some name-clash resolution and decided for `script:version`. It seems to be a good idea, to continue using this namespace.

### 🔮 Future

For future CKEditor 5 updates (planned 40+), we should switch to fixed CKEditor 5 dependencies. Then, the check will provide relevant feedback after `pnpm update`. For now, it only provides a gain for manually added/changed dependencies.