### PR TITLE
fix(link): Harden Default Target Calculation

### DIFF
--- a/packages/ckeditor5-coremedia-link/src/linktarget/LinkTargetModelView.ts
+++ b/packages/ckeditor5-coremedia-link/src/linktarget/LinkTargetModelView.ts
@@ -110,17 +110,30 @@ export default class LinkTargetModelView extends Plugin {
    * @private
    */
   #computeLinkTarget(diffItem: DiffItem): string | undefined {
+    let url: unknown;
+
     if (this.#isDiffItemAttribute(diffItem)) {
-      // The linkHref attribute was added/changed for this node
-      // This might happen if an existing link gets edited e.g. if the link url gets changed.
-      return computeDefaultLinkTargetForUrl(diffItem.attributeNewValue as string, this.editor.config);
+      // The linkHref attribute was added/changed/deleted for this node.
+      //
+      // This might happen if an existing link gets edited, e.g., if the link
+      // URL gets changed.
+      //
+      // It is the new value, that is relevant for us here. Note, that this
+      // code is also invoked when links get removed, so that the new attribute
+      // value is `null` then.
+      url = diffItem.attributeNewValue;
     }
 
     if (this.#isDiffItemInsert(diffItem)) {
-      // An entry with linkHref attribute was inserted
-      // This applies to links, created via the link balloon and contents dropped into the
-      // editor or into the link balloon
-      return computeDefaultLinkTargetForUrl(diffItem.attributes.get("linkHref") as string, this.editor.config);
+      // An entry with linkHref attribute was inserted.
+      //
+      // This applies to links, created via the link balloon and contents
+      // dropped into the editor or into the link balloon.
+      url = diffItem.attributes.get("linkHref");
+    }
+
+    if (url && typeof url === "string") {
+      return computeDefaultLinkTargetForUrl(url, this.editor.config);
     }
 
     return undefined;

--- a/packages/ckeditor5-coremedia-link/src/linktarget/config/LinkTargetConfig.ts
+++ b/packages/ckeditor5-coremedia-link/src/linktarget/config/LinkTargetConfig.ts
@@ -11,6 +11,7 @@ import {
   TargetDefaultRuleDefinitionWithFilter,
 } from "./LinkTargetDefaultRuleDefinition";
 import { getFilterByType } from "./DefaultTargetTypeFilters";
+import { LoggerProvider } from "@coremedia/ckeditor5-logging";
 
 /**
  * Provides the given targets to select from and a list of rules to
@@ -68,6 +69,8 @@ interface LinkTargetConfig {
   defaultTargets?: TargetDefaultRuleDefinition[];
 }
 
+const logger = LoggerProvider.getLogger("LinkTargetConfig");
+
 /**
  * Parses a possibly existing configuration option as part of CKEditor's
  * link plugin configuration. It expects an entry `defaultTargets` which contains an
@@ -121,8 +124,14 @@ export const computeDefaultLinkTargetForUrl = (url: string, config: Config<Edito
   const defaultTargetConfig = parseDefaultLinkTargetConfig(config);
   let result: string | undefined;
   defaultTargetConfig.forEach((defaultTarget) => {
-    if (defaultTarget.filter(url)) {
-      result = defaultTarget.target;
+    try {
+      if (defaultTarget.filter(url)) {
+        result = defaultTarget.target;
+      }
+    } catch (e) {
+      // We invoked possibly custom code here and should be robust, when the
+      // corresponding configuration contains an error.
+      logger.warn(`Ignoring failure while evaluating default target for URL '${url}'.`, e);
     }
   });
   return result;


### PR DESCRIPTION
The post-fixer for links is also invoked when removing links. In this case, the calculated link is `null`.

The previous code struggled, because brute-force casting to `string` instead of doing some type-checking.

Also, the previous code was not robust, when any of the filters got an issue. As such filters may be part of the configuration, we should be robust on invocation and handle it in some predictable way.

The fix is two-fold:

* We do not invoke the filter on link removal anymore.
* We added a robustness layer for custom filters, if they fail with exception. Decision is to ignore the corresponding filter, which is, that on failure, no default target will be selected.