### PR TITLE
Deal with GitHub Actions Node.js 16 Deprecations

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -113,7 +113,7 @@ jobs:
           run_install: false
       - id: installNodeJs
         name: "Install: Use Node.js ${{ env.nodeVersion }}"
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ env.nodeVersion }}
           cache: "pnpm"

--- a/.github/workflows/get-version.yml
+++ b/.github/workflows/get-version.yml
@@ -70,7 +70,7 @@ jobs:
           run_install: false
       - id: installNodeJs
         name: "Install: Use Node.js ${{ env.nodeVersion }}"
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ env.nodeVersion }}
           cache: "pnpm"

--- a/.github/workflows/pre-release-gc.yml
+++ b/.github/workflows/pre-release-gc.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v3
       - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Set up .npmrc

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -37,7 +37,7 @@ jobs:
           echo "Allocated Pull Request number ${prnumber}"
           echo "::set-output name=prnumber::${prnumber}"
       - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Configure NPM

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
           echo "For maintenance branches only patch versions are allowed."
           exit 1
       - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Configure NPM


### PR DESCRIPTION
Using Node.js 20, we now get warnings such as:

```
Node.js 16 actions are deprecated.
  Please update the following actions to use Node.js 20:
  actions/checkout@v3, actions/setup-node@v3.
  For more information see:
  https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```

To address this, an update of the corresponding actions is required. PNPM, though, does not provide a solution yet.