### PR TITLE
feat(coremedia-richtext): TSdoc and allowEmpty (XLink)

### DIFF
--- a/packages/ckeditor5-coremedia-richtext/src/rules/ImageElements.ts
+++ b/packages/ckeditor5-coremedia-richtext/src/rules/ImageElements.ts
@@ -56,7 +56,7 @@ export const imageElements: RuleConfig = {
       if (isHTMLImageElement(node)) {
         // title: Not mapping xlink:title to title yet, as we use the title
         // for generating tooltips regarding the related content.
-        setXLinkDataSetEntries(node, extractXLinkAttributes(node), true);
+        setXLinkDataSetEntries(node, extractXLinkAttributes(node));
         node.src = INLINE_IMG;
       }
       return node;

--- a/packages/ckeditor5-coremedia-richtext/src/rules/ImageElements.ts
+++ b/packages/ckeditor5-coremedia-richtext/src/rules/ImageElements.ts
@@ -56,7 +56,7 @@ export const imageElements: RuleConfig = {
       if (isHTMLImageElement(node)) {
         // title: Not mapping xlink:title to title yet, as we use the title
         // for generating tooltips regarding the related content.
-        setXLinkDataSetEntries(node, extractXLinkAttributes(node));
+        setXLinkDataSetEntries(node, extractXLinkAttributes(node), true);
         node.src = INLINE_IMG;
       }
       return node;

--- a/packages/ckeditor5-coremedia-richtext/src/rules/XLink.ts
+++ b/packages/ckeditor5-coremedia-richtext/src/rules/XLink.ts
@@ -61,11 +61,29 @@ export const extractXLinkDataSetEntries = (element: HTMLElement): XLinkAttribute
     })
     .reduce(mergeXLinkAttributes) ?? {};
 
-export const setXLinkAttributes = (element: Element, attributes: XLinkAttributes): void => {
+/**
+ * Sets attributes of the `xlink` namespace for the given element.
+ *
+ * Attributes already set before will be overwritten.
+ *
+ * @example
+ *
+ * ```typescript
+ * setXLinkAttributes(element, {
+ *   // empty: Ignored by default.
+ *   "title": "",
+ *   "href": "https://example.org/"
+ * });
+ * ```
+ *
+ * @param element - the elemant to set the attributes at
+ * @param attributes - the key-value pairs of attributes to set
+ * @param allowEmpty - if to ignore entries with empty values or not
+ */
+export const setXLinkAttributes = (element: Element, attributes: XLinkAttributes, allowEmpty = false): void => {
   const { ownerDocument } = element;
   Object.entries(attributes).forEach(([key, value]: [XLinkAttributeKey, string | undefined]) => {
-    // We ignore empty values. Thus, only add if non-empty.
-    if (value) {
+    if (value || allowEmpty) {
       const qualifiedName: XLinkAttributeQualifiedName = `${xLinkPrefix}:${key}`;
       const xlinkAttribute = ownerDocument.createAttributeNS(xLinkNamespaceUri, qualifiedName);
       xlinkAttribute.value = value;

--- a/packages/ckeditor5-coremedia-richtext/src/rules/XLink.ts
+++ b/packages/ckeditor5-coremedia-richtext/src/rules/XLink.ts
@@ -66,6 +66,8 @@ export const extractXLinkDataSetEntries = (element: HTMLElement): XLinkAttribute
  *
  * Attributes already set before will be overwritten.
  *
+ * This method is typically used in `toData` mapping.
+ *
  * @example
  *
  * ```typescript
@@ -83,7 +85,7 @@ export const extractXLinkDataSetEntries = (element: HTMLElement): XLinkAttribute
 export const setXLinkAttributes = (element: Element, attributes: XLinkAttributes, allowEmpty = false): void => {
   const { ownerDocument } = element;
   Object.entries(attributes).forEach(([key, value]: [XLinkAttributeKey, string | undefined]) => {
-    if (value || allowEmpty) {
+    if (typeof value === "string" && (value || allowEmpty)) {
       const qualifiedName: XLinkAttributeQualifiedName = `${xLinkPrefix}:${key}`;
       const xlinkAttribute = ownerDocument.createAttributeNS(xLinkNamespaceUri, qualifiedName);
       xlinkAttribute.value = value;
@@ -98,10 +100,29 @@ export const setXLinkAttributes = (element: Element, attributes: XLinkAttributes
   });
 };
 
-export const setXLinkDataSetEntries = (element: HTMLElement, attributes: XLinkAttributes): void => {
+/**
+ * Sets attributes that originate from `xlink` attributes as `dataset` entries
+ * instead. This method is meant to be used in `toView` mapping as a suggestion
+ * how to _secure_ `xlink` attributes that may otherwise get lost outside the
+ * CKEditor 5 data layer (thus, model and editing view).
+ *
+ * @example
+ *
+ * ```typescript
+ * setXLinkDataSetEntries(element, {
+ *   // empty: Ignored by default.
+ *   "title": "",
+ *   "href": "https://example.org/"
+ * });
+ * ```
+ *
+ * @param element - the elemant to set the attributes at
+ * @param attributes - the key-value pairs of attributes to set
+ * @param allowEmpty - if to ignore entries with empty values or not
+ */
+export const setXLinkDataSetEntries = (element: HTMLElement, attributes: XLinkAttributes, allowEmpty = false): void => {
   Object.entries(attributes).forEach(([localName, value]: [XLinkAttributeKey, string | undefined]) => {
-    // We ignore empty values. Thus, only add if non-empty.
-    if (typeof value === "string") {
+    if (typeof value === "string" && (value || allowEmpty)) {
       const key: XLinkAttributeDataSetKey = `${xLinkPrefix}${capitalize(localName)}`;
       element.dataset[key] = value;
     }

--- a/packages/ckeditor5-coremedia-richtext/src/rules/XLink.ts
+++ b/packages/ckeditor5-coremedia-richtext/src/rules/XLink.ts
@@ -72,7 +72,7 @@ export const extractXLinkDataSetEntries = (element: HTMLElement): XLinkAttribute
  *
  * ```typescript
  * setXLinkAttributes(element, {
- *   // empty: Ignored by default.
+ *   // empty: Ignored, if allowEmpty=false
  *   "title": "",
  *   "href": "https://example.org/"
  * });
@@ -80,9 +80,9 @@ export const extractXLinkDataSetEntries = (element: HTMLElement): XLinkAttribute
  *
  * @param element - the elemant to set the attributes at
  * @param attributes - the key-value pairs of attributes to set
- * @param allowEmpty - if to ignore entries with empty values or not
+ * @param allowEmpty - if to ignore entries with empty values or not; default: `true`
  */
-export const setXLinkAttributes = (element: Element, attributes: XLinkAttributes, allowEmpty = false): void => {
+export const setXLinkAttributes = (element: Element, attributes: XLinkAttributes, allowEmpty = true): void => {
   const { ownerDocument } = element;
   Object.entries(attributes).forEach(([key, value]: [XLinkAttributeKey, string | undefined]) => {
     if (typeof value === "string" && (value || allowEmpty)) {
@@ -110,7 +110,7 @@ export const setXLinkAttributes = (element: Element, attributes: XLinkAttributes
  *
  * ```typescript
  * setXLinkDataSetEntries(element, {
- *   // empty: Ignored by default.
+ *   // empty: Ignored, if allowEmpty=false
  *   "title": "",
  *   "href": "https://example.org/"
  * });
@@ -118,9 +118,9 @@ export const setXLinkAttributes = (element: Element, attributes: XLinkAttributes
  *
  * @param element - the elemant to set the attributes at
  * @param attributes - the key-value pairs of attributes to set
- * @param allowEmpty - if to ignore entries with empty values or not
+ * @param allowEmpty - if to ignore entries with empty values or not; default: `true`
  */
-export const setXLinkDataSetEntries = (element: HTMLElement, attributes: XLinkAttributes, allowEmpty = false): void => {
+export const setXLinkDataSetEntries = (element: HTMLElement, attributes: XLinkAttributes, allowEmpty = true): void => {
   Object.entries(attributes).forEach(([localName, value]: [XLinkAttributeKey, string | undefined]) => {
     if (typeof value === "string" && (value || allowEmpty)) {
       const key: XLinkAttributeDataSetKey = `${xLinkPrefix}${capitalize(localName)}`;


### PR DESCRIPTION
Adds TSdoc and a new feature to `setXLinkAttributes` in `XLink` tooling.

`allowEmpty` is required to be `true` if, for example, you need to explicitly set a value for a required attribute and it must not be skipped (such as an `<a>` which aways requires `xlink:href` to comply with CoreMedia Rich Text DTD 1.0).

To not break existing usages, `allowEmpty` must default to `false`.

**Decide on breaking change:**

As additional part of this PR, also decided to align the behavior of `setXLinkDataSetEntries`
with `setXLinkAttributes`, thus, to (by default) drop attributes with empty values. While this
is aligned with the DevNote that existed before, this has to be considered a **breaking change**.

Usages that rely on "empty values" to be accepted, need to explicitly add `allowEmpty = true` to the call.

The defensive option would be to set the default to `true` for this method, but this again makes it harder to "learn the API by heart" due to the difference of `setXLinkAttributes`.

As an alternative to this, perhaps even the better one, is to make `allowEmpty` default to `true` for both. For a newly developed API, this would be my recommendation as "stripping given (empty) values" is more of a convenience behavior that spares some extra lines to filter the attributes before handing them over to the API.

This again, would of course also be breaking, but this time for `setXLinkAttributes`.