### PR TITLE
CKE-67 Keep an attribute with valid fixed value

### DIFF
--- a/app/src/editors/richtext.ts
+++ b/app/src/editors/richtext.ts
@@ -66,6 +66,7 @@ import type {
 import {
   replaceByElementAndClassBackAndForth,
   replaceElementByElementAndClass,
+  stripFixedAttributes,
 } from "@coremedia/ckeditor5-coremedia-richtext";
 import "ckeditor5/ckeditor5.css";
 import { FilterRuleSetConfiguration } from "@coremedia/ckeditor5-dataprocessor-support";
@@ -111,6 +112,7 @@ const richTextRuleConfigurations: RuleConfig[] = [
     // we may skip it here.
     dataReservedClass: "mark",
   }),
+  stripFixedAttributes(),
 ];
 
 /**

--- a/packages/ckeditor5-coremedia-richtext/README.md
+++ b/packages/ckeditor5-coremedia-richtext/README.md
@@ -238,6 +238,25 @@ here, to reduce the overhead in rule implementation. `renameElement`, for
 example, provides an element of the new name, but with all attributes copied
 from original element.
 
+#### Strict Attributes
+
+Some attributes on HTML elements are `fixed`, according to the `RichTextDtd`.
+You might find those attributes obsolete and want to strip them from the created markup.
+Please use the `stripFixedAttributes` rule in your editor's configuration to remove them:
+
+```typescript
+import { stripFixedAttributes } from "@coremedia/ckeditor5-coremedia-richtext";
+
+ClassicEditor.create(document.querySelector('.editor'), {
+  // ...
+  "coremedia:richtext": {
+    rules: [
+      // ...
+      stripFixedAttributes()],
+  },
+});
+```
+
 #### API Usage
 
 Along with configuration as part of the CKEditor 5 instance creation, you may

--- a/packages/ckeditor5-coremedia-richtext/__tests__/rules/FixedAttributes.test.ts
+++ b/packages/ckeditor5-coremedia-richtext/__tests__/rules/FixedAttributes.test.ts
@@ -1,0 +1,32 @@
+// noinspection HtmlUnknownAttribute,HtmlRequiredAltAttribute
+
+import * as aut from "../../src/rules/FixedAttributes";
+import { richtext } from "@coremedia-internal/ckeditor5-coremedia-example-data/src/RichTextBase";
+import { TestDirection, toData } from "./TestDirection";
+import { RulesTester } from "./RulesTester";
+
+describe("FixedAttributes", () => {
+  const ruleConfigurations = [aut.stripFixedAttributes()];
+
+  describe.each`
+    view                                                           | direction | data
+    ${`<pre xml:space="preserve"></pre>`}                          | ${toData} | ${`<pre></pre>)>`}
+    ${`<a xlink:type="simple"></a>`}                               | ${toData} | ${`<a></a>`}
+    ${`<img xlink:show="embed"/>`}                                 | ${toData} | ${`<img/>`}
+    ${`<img xlink:type="simple" xlink:show="embed" />`}            | ${toData} | ${`<img/>`}
+    ${`<a xlink:type="simple"><img xlink:actuate="onLoad" /></a>`} | ${toData} | ${`<a><img/></a>`}
+  `(
+    "[$#] Should provide mapping from data $direction view: $data $direction $view",
+    ({ data, direction, view }: { data: string; direction: TestDirection; view: string }) => {
+      const dataString = richtext(data);
+      const htmlString = `<body>${view}</body>`;
+      const tester = new RulesTester(ruleConfigurations, "*", "body > *");
+
+      tester.executeTests({
+        dataString,
+        direction,
+        htmlString,
+      });
+    },
+  );
+});

--- a/packages/ckeditor5-coremedia-richtext/__tests__/sanitation/RichTextSanitizer.test.ts
+++ b/packages/ckeditor5-coremedia-richtext/__tests__/sanitation/RichTextSanitizer.test.ts
@@ -444,12 +444,9 @@ describe("RichTextSanitizer", () => {
             });
           });
 
-          it("Should remove fixed attribute (silently)", () => {
-            const optimizedXml = richtext(pre());
-            const originalXml = richtext(pre("", { "xml:space": "preserve" }));
-            expectSanitationResult(sanitizer, originalXml, optimizedXml, (listener) => {
-              expect(listener.totalLength).toStrictEqual(0);
-            });
+          it("Should keep valid fixed attribute", () => {
+            const validXml = richtext(pre("", { "xml:space": "preserve" }));
+            expectSanitationResult(sanitizer, validXml, validXml);
           });
 
           it.each`
@@ -646,12 +643,9 @@ describe("RichTextSanitizer", () => {
             });
           });
 
-          it("Should remove fixed attribute (silently)", () => {
-            const optimizedXml = richtext(p(a("", { "xlink:href": "" })));
-            const originalXml = richtext(p(a("", { "xlink:href": "", "xlink:type": "simple" })));
-            expectSanitationResult(sanitizer, originalXml, optimizedXml, (listener) => {
-              expect(listener.totalLength).toStrictEqual(0);
-            });
+          it("Should keep valid fixed attribute", () => {
+            const validXml = richtext(p(a("", { "xlink:href": "", "xlink:type": "simple" })));
+            expectSanitationResult(sanitizer, validXml, validXml);
           });
 
           it.each`
@@ -862,14 +856,12 @@ describe("RichTextSanitizer", () => {
 
           it.each`
             withFixed
+            ${img({ "alt": "", "xlink:href": "", "xlink:type": "simple" })}
             ${img({ "alt": "", "xlink:href": "", "xlink:show": "embed" })}
             ${img({ "alt": "", "xlink:href": "", "xlink:actuate": "onLoad" })}
-          `("[$#] Should remove fixed attribute (silently): $withFixed", ({ withFixed }: { withFixed: string }) => {
-            const optimizedXml = richtext(p(img({ "alt": "", "xlink:href": "" })));
-            const originalXml = richtext(p(withFixed));
-            expectSanitationResult(sanitizer, originalXml, optimizedXml, (listener) => {
-              expect(listener.totalLength).toStrictEqual(0);
-            });
+          `("[$#] Should keep fixed attribute: $withFixed", ({ withFixed }: { withFixed: string }) => {
+            const validXml = richtext(p(withFixed));
+            expectSanitationResult(sanitizer, validXml, validXml);
           });
 
           it("Should add missing required attribute (silently)", () => {

--- a/packages/ckeditor5-coremedia-richtext/src/index.ts
+++ b/packages/ckeditor5-coremedia-richtext/src/index.ts
@@ -49,5 +49,6 @@ export {
   preProcessAnchorElement,
   type HTMLAnchorElementPreprocessor,
 } from "./rules/AnchorElements";
+export { stripFixedAttributes } from "./rules/FixedAttributes";
 
 import "./augmentation";

--- a/packages/ckeditor5-coremedia-richtext/src/rules/FixedAttributes.ts
+++ b/packages/ckeditor5-coremedia-richtext/src/rules/FixedAttributes.ts
@@ -1,0 +1,39 @@
+import { RuleConfig } from "@coremedia/ckeditor5-dom-converter";
+
+const fixedAttributes = new Map<string, Map<string, string>>([
+  ["pre", new Map([["xml:space", "preserve"]])],
+  ["a", new Map([["xlink:type", "simple"]])],
+  [
+    "img",
+    new Map([
+      ["xlink:type", "simple"],
+      ["xlink:show", "embed"],
+      ["xlink:actuate", "onLoad"],
+    ]),
+  ],
+]);
+
+/**
+ * RichTextSanitizer keeps an attribute with a valid fixed value.
+ * If such an attribute should be removed before storing, then this rule can be used.
+ * @example For an attribute with valid fixed value
+ * ```html
+ * <a href="" xlink:type="simple">
+ * ```
+ */
+export const stripFixedAttributes = (): RuleConfig => ({
+  toData: {
+    id: "strip-fixed-attributes",
+    prepare: (node: Node): void => {
+      if (node instanceof HTMLElement) {
+        if (Array.from(fixedAttributes.keys()).includes(node.localName)) {
+          fixedAttributes.get(node.localName)?.forEach((value, attribute) => {
+            if (node.hasAttribute(attribute) && node.getAttribute(attribute) === value) {
+              node.removeAttribute(attribute);
+            }
+          });
+        }
+      }
+    },
+  },
+});

--- a/packages/ckeditor5-coremedia-richtext/src/rules/FixedAttributes.ts
+++ b/packages/ckeditor5-coremedia-richtext/src/rules/FixedAttributes.ts
@@ -36,4 +36,5 @@ export const stripFixedAttributes = (): RuleConfig => ({
       }
     },
   },
+  priority: "lowest",
 });

--- a/packages/ckeditor5-coremedia-richtext/src/rules/index-doc.ts
+++ b/packages/ckeditor5-coremedia-richtext/src/rules/index-doc.ts
@@ -12,6 +12,7 @@ export * from "./CodeElements";
 export * from "./DefaultRules";
 export * from "./Direction";
 export * from "./DivElements";
+export * from "./FixedAttributes";
 export * from "./HeadingElements";
 export * from "./ImageElements";
 export * from "./LanguageAttributes";

--- a/packages/ckeditor5-coremedia-richtext/src/sanitation/ElementConfig.ts
+++ b/packages/ckeditor5-coremedia-richtext/src/sanitation/ElementConfig.ts
@@ -311,11 +311,10 @@ export class ElementConfig {
     } else {
       const { fixed } = config;
       const { value } = attribute;
-      // Cleanup: Remove fixed attributes, that are irrelevant to store.
       if (fixed && fixed === value) {
-        // Cleanup: We expect a fixed value to be valid by definition and that
-        // it is obsolete to forward it to stored data.
-        element.removeAttributeNode(attribute);
+        // When an attribute with valid fixed value is specified,
+        // we should keep it.
+        // a data processing rule may remove it before if wished.
       } else if (!config.validateValue(value, strictness)) {
         listener.removeInvalidAttr(element, attribute, "invalidValue");
         element.removeAttributeNode(attribute);


### PR DESCRIPTION
`RichTextSanitizer` used to remove an attribute if it has a fixed valid value as it seemed obsolete. E.g. `<img xlink:show= "embed">`. Now such an attribute is kept, stored and therefore can be used in the presentation layer. 

To restore the old behavior which removes such an attribute use the provided data processing rule `stripFixedAttributes`.